### PR TITLE
Updating authentication flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,14 @@
-
+# v.1.0.9
+#### @hakit/core
+- Refactored HassConnect authentication as sometimes it was not rendering the children until a manual refresh was performed.
+- NEW - HassConnect - options prop added to pass down options to the provider
+   - throttle - determine the default throttle amount to use for all entity updates (default is 150ms)
+   - allowNonSecure - allow non https urls to authenticate (default is false), localhost is accepted by default
+   - preloadConfiguration - if the configuration object should fetch before children render (default is false)
+- loadTokens, saveTokens logic is identical to the home assistant auth flow, this is to ensure the tokens are saved correctly and can be used in the future, these functions are exposed from core under loadTokens and saveTokens
+- Adding more error handling to the authentication flow
+- NEW - returning logout method from useHass hook, this will clear the tokens and force a re-authentication
+- Previously, authentication was checking the current url last authenticated with, this may have been causing issues with the authentication flow, this has been removed and will authenticate correctly if there's tokens present in local storage.
 # v1.0.11
 #### @hakit/components
 - adding new dark theme color scheme for scroll bars / other browser specific changes

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -19,7 +19,7 @@
     "custom"
   ],
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=16.0.0"
   },
   "description": "A collection of React hooks and helpers for Home Assistant to easily communicate with the Home Assistant WebSocket API.",
   "main": "dist/hakit-core.umd.js",

--- a/packages/core/src/HassConnect/index.tsx
+++ b/packages/core/src/HassConnect/index.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
 import { useRef } from "react";
 import { HassProvider } from "./Provider";
+import type { HassProviderProps } from "./Provider";
 
 export type HassConnectProps = {
   /** Any react node to render when authenticated */
@@ -9,8 +10,10 @@ export type HassConnectProps = {
   hassUrl: string;
   /** Any react node to render when not authenticated */
   fallback?: ReactNode;
-  /** called once the connection is successful, and only once */
+  /** called once the entity subscription is successful, and only once */
   onReady?: () => void;
+  /** options for the provider */
+  options?: Omit<HassProviderProps, "children" | "hassUrl">;
 };
 /** This component will show the Home Assistant login form you're used to seeing normally when logging into HA, once logged in you shouldn't see this again unless you clear device storage, once authenticated it will render the child components of HassConnect and provide access to the api. */
 export const HassConnect = ({
@@ -18,6 +21,7 @@ export const HassConnect = ({
   hassUrl,
   fallback = null,
   onReady,
+  options = {},
 }: HassConnectProps): JSX.Element => {
   const onReadyCalled = useRef(false);
   if (!hassUrl) {
@@ -26,7 +30,7 @@ export const HassConnect = ({
     );
   }
   return (
-    <HassProvider hassUrl={hassUrl}>
+    <HassProvider hassUrl={hassUrl} {...options}>
       {(ready) => {
         if (ready && onReady && !onReadyCalled.current) {
           onReady();

--- a/packages/core/src/HassConnect/token-storage.ts
+++ b/packages/core/src/HassConnect/token-storage.ts
@@ -1,0 +1,62 @@
+import { AuthData } from "home-assistant-js-websocket";
+
+const storage = window.localStorage || {};
+
+declare global {
+  interface Window {
+    __tokenCache: {
+      // undefined: we haven't loaded yet
+      // null: none stored
+      tokens?: AuthData | null;
+      writeEnabled: boolean;
+    };
+  }
+}
+
+const extractSearchParam = (param: string): string | null => {
+  const urlParams = new URLSearchParams(window.location.search);
+  return urlParams.get(param);
+};
+
+let tokenCache = window.__tokenCache;
+if (!tokenCache) {
+  tokenCache = window.__tokenCache = {
+    tokens: undefined,
+    writeEnabled: true,
+  };
+}
+
+export function saveTokens(tokens: AuthData | null) {
+  tokenCache.tokens = tokens;
+
+  if (!tokenCache.writeEnabled && extractSearchParam("storeToken") === "true") {
+    tokenCache.writeEnabled = true;
+  }
+
+  if (tokenCache.writeEnabled) {
+    try {
+      storage.hassTokens = JSON.stringify(tokens);
+    } catch (err: any) {
+      // write failed, ignore it. Happens if storage is full or private mode.
+    }
+  }
+}
+
+export function loadTokens() {
+  if (tokenCache.tokens === undefined) {
+    try {
+      // Delete the old token cache.
+      delete storage.tokens;
+      const tokens = storage.hassTokens;
+      if (tokens) {
+        tokenCache.tokens = JSON.parse(tokens);
+        tokenCache.writeEnabled = true;
+      } else {
+        tokenCache.tokens = null;
+      }
+    } catch (err: any) {
+      tokenCache.tokens = null;
+    }
+  }
+  return tokenCache.tokens;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -8,6 +8,9 @@ export * from "./data/light";
 // components
 export { HassConnect } from "./HassConnect";
 export { HassContext } from "./HassConnect/Provider";
+// tokens
+export { loadTokens, saveTokens } from "./HassConnect/token-storage";
+
 // types
 export type { HassContextProps, Route } from "./HassConnect/Provider";
 export type { HassConnectProps } from "./HassConnect";

--- a/stories/2.testConnection.stories.tsx
+++ b/stories/2.testConnection.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Source } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { HassConnect, HassContext, useHass } from '@core';
+import { HassConnect, HassContext, useHass, loadTokens } from '@core';
 import { useContext, useState, useEffect, useMemo } from "react";
 import type {
   HassServices,
@@ -27,18 +27,14 @@ interface ApiTesterProps {
 }
 
 function ApiTester({ domains, entities }: ApiTesterProps) {
-  const { callService, getAllEntities, getConfig } = useHass();
+  const { callService, getAllEntities, config } = useHass();
   const [domain, setDomain] = useState<string>("light");
   const [service, setService] = useState<string>("");
   const [entity, setEntity] = useState<string>("");
   console.group('All Entities');
   console.log(getAllEntities());
   console.groupEnd();
-  useEffect(() => {
-    getConfig().then((config) => {
-      console.log('config', config);
-    });
-  }, [getConfig])
+  console.log('ConfigurationObject', config);
   const availableEntities = useMemo(() => {
     // filter the entities that are prefixed with the domain,
     return Object.entries(entities)
@@ -247,7 +243,7 @@ export function Test${upperFirst(camelCase(domain))}{
 }
 
 function UseData() {
-  const { getAllEntities, getServices } = useContext(HassContext);
+  const { getAllEntities, getServices, config } = useContext(HassContext);
   const entities = getAllEntities();
   const [services, setServices] = useState<HassServices | null>(null);
   const hasEntities = useMemo(
@@ -274,6 +270,7 @@ function UseData() {
 function Template() {
   const storedHassUrl = localStorage.getItem("hassUrl");
   const storedHassTokens = localStorage.getItem("hassTokens");
+  console.log('storedHassTokens', storedHassTokens, loadTokens());
   const isAuthRedirect = window.location.href.includes("auth_callback");
   const [error, setError]  = useState<string>("");
   const [hassUrl, setHassUrl] = useState<string>(storedHassTokens === null && !isAuthRedirect ? "" : storedHassUrl || '');
@@ -344,7 +341,10 @@ function Template() {
         </Grid>
       </Grid>
       </CssBaseline>
-        {ready && <HassConnect hassUrl={hassUrl}>
+        {ready && <HassConnect hassUrl={hassUrl} options={{
+          allowNonSecure: true,
+          preloadConfiguration: true,
+        }}>
           <UseData />
         </HassConnect>}
     </>

--- a/stories/HassConnectFake.tsx
+++ b/stories/HassConnectFake.tsx
@@ -10,6 +10,7 @@ import type {
   Connection,
   HassEntities,
   HassConfig,
+  Auth,
 } from "home-assistant-js-websocket";
 import type {
   ServiceData,
@@ -49,7 +50,7 @@ const MODE_TO_HVAC_ACTION: {
   'fan_only': 'fan',
 }
 
-const fakeConfig = {
+const fakeConfig: HassConfig = {
   "latitude": -33.25779010313883,
   "longitude": 151.4821529388428,
   "elevation": 0,
@@ -77,7 +78,27 @@ const fakeConfig = {
   "currency": "AUD",
   "country": "AU",
   "language": "en"
-} satisfies HassConfig;
+};
+
+const fakeAuth: Auth = {
+  data: {
+    hassUrl: "",
+    clientId: null,
+    expires: 0,
+    refresh_token: "",
+    access_token: "",
+    expires_in: 0
+  },
+  wsUrl: "",
+  accessToken: "",
+  expired: false,
+  refreshAccessToken: function (): Promise<void> {
+    throw new Error("Function not implemented.");
+  },
+  revoke: function (): Promise<void> {
+    throw new Error("Function not implemented.");
+  }
+}
 
 function HassProvider({
   children,
@@ -300,6 +321,9 @@ function HassProvider({
         ready,
         routes,
         lastUpdated,
+        auth: fakeAuth,
+        config: fakeConfig,
+        logout: () => null,
       }}
     >
       {children(ready)}


### PR DESCRIPTION
# v.1.0.9
#### @hakit/core
- Refactored HassConnect authentication as sometimes it was not rendering the children until a manual refresh was performed.
- NEW - HassConnect - options prop added to pass down options to the provider
   - throttle - determine the default throttle amount to use for all entity updates (default is 150ms)
   - allowNonSecure - allow non https urls to authenticate (default is false), localhost is accepted by default
   - preloadConfiguration - if the configuration object should fetch before children render (default is false)
- loadTokens, saveTokens logic is identical to the home assistant auth flow, this is to ensure the tokens are saved correctly and can be used in the future, these functions are exposed from core under loadTokens and saveTokens
- Adding more error handling to the authentication flow
- NEW - returning logout method from useHass hook, this will clear the tokens and force a re-authentication
- Previously, authentication was checking the current url last authenticated with, this may have been causing issues with the authentication flow, this has been removed and will authenticate correctly if there's tokens present in local storage.