### PR TITLE
Fix types sync script, add docs

### DIFF
--- a/packages/core/bin/index.ts
+++ b/packages/core/bin/index.ts
@@ -41,11 +41,8 @@ export async function typeSync({
       }
     }`;
   const outDir = _outDir || process.cwd();
-  const formatted = await prettier.format(output, {
-    parser: 'typescript'
-  });
   // now write the file
-  fs.writeFileSync(`${outDir}/${filename}`, formatted);
+  fs.writeFileSync(`${outDir}/${filename}`, output);
   console.log(`Succesfully generated types: ${outDir}/${filename}\n\n`);
   // reminder to add the generated file to the tsconfig.json include array
   console.log(`IMPORTANT: Don't forget to add the "${filename}" file to your tsconfig.json include array\n\n`);

--- a/packages/core/bin/service-generator.ts
+++ b/packages/core/bin/service-generator.ts
@@ -41,7 +41,7 @@ const resolveSelectorType = (selector: Selector) => {
   return 'object';
 }
 
-
+const sanitize = (str: string | undefined) => (str ? str.replace(/"/g, "'").replace(/[\n\r]+/g, ' ') : '');
 
 export const generateServiceTypes = (input: HassServices, whitelist: string[] = []) => {
   const interfaces = Object.entries(input).map(([domain, services]) => {
@@ -52,12 +52,12 @@ export const generateServiceTypes = (input: HassServices, whitelist: string[] = 
       const camelService = _.camelCase(service);
       const data = Object.entries<Field>(fields as unknown as { [key: string]: Field }).map(([field, { selector, example, required, description }]) => {
         const type = field in REMAPPED_TYPES ? REMAPPED_TYPES[field] : resolveSelectorType(selector as Selector);
-        const exampleUsage = example ? ` @example ${`${example}`.replace(/"/g, "'").replace(/[\n\r]+/g, ' ')}` : '';
-        return `// ${description}${exampleUsage}\n${field}${required ? '' : '?'}: ${type};`;
+        const exampleUsage = example ? ` @example ${sanitize(String(example))}` : '';
+        return `// ${sanitize(String(description))}${exampleUsage}\n${field}${required ? '' : '?'}: ${type};`;
       });
       const serviceData = `${Object.keys(fields).length === 0 ? 'object' : `{${data.join('\n')}}`}`;
 
-      return `// ${description}
+      return `// ${sanitize(String(description))}
               ${camelService}: ServiceFunction<T, ${serviceData}>;
             `;
     }).join('')}

--- a/stories/6.typescriptSync.mdx
+++ b/stories/6.typescriptSync.mdx
@@ -92,3 +92,7 @@ I recommend you run this script before every build, so that you always have the 
 }
 
 `} />
+
+## Linting
+
+Lint the resulting file yourself, it being a separate step allows some output and better debugging when the file ends up invalid, and you can bring your own linter rules.

--- a/stories/advanced/modifyingHakit.mdx
+++ b/stories/advanced/modifyingHakit.mdx
@@ -1,0 +1,69 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="ADVANCED/Modifying hakit" />
+
+# Modifying @hakit
+
+## Using local version of @hakit
+
+1. Clone and setup the repo alongside your dashboard project 
+```shell
+git clone https://github.com/shannonhochkins/ha-component-kit.git
+cd ha-component-kit
+npm install
+```
+
+2. Build and watch library changes
+```
+npm run watch:build:core
+```
+
+3. In your dashboard project, add aliases for `@hakit` and `react` to `vite.config.ts`
+```js
+export default defineConfig({
+  plugins: [react(), viteTsconfigPaths()],
+  resolve: {
+    alias: {
+      '@hakit/core': path.resolve(
+        __dirname,
+        '../ha-component-kit/packages/core/dist/hakit-core.es.js',
+      ),
+      react: path.resolve('./node_modules/react'),
+      'react-dom': path.resolve('./node_modules/react-dom'),
+    },
+  },
+})
+```
+4. Start your dashboard project
+
+5. When getting an error of missing dependencies, run `npm link libraryName` first at the dashboard root, then at `ha-component-kit`
+
+
+## Developing node scripts
+
+1. Navigate into `ha-component-kit/packages/core`
+
+2. Make some changes to the scripts in the `packages/core/bin`
+
+3. Build the script you modified, e.g. `npm run build:sync-script`
+
+4. Import the transpiled output file directly, e.g.
+```ts
+// import { typeSync } from '@hakit/core/sync' // usual import, comment out
+import { typeSync } from '../ha-component-kit/packages/core/dist/sync/node/index.js'
+
+async function runner() {
+  await typeSync({
+    url: 'YOUR_HOME_ASSISTANT_URL',
+    token: 'YOUR_LONG_LIVED_TOKEN'
+  })
+}
+runner()
+```
+
+5. Run it as usual, but remember to use `--esm`
+```shell
+ ./node_modules/.bin/ts-node --esm ./sync.ts
+```
+
+6. If encountering esm issues, make sure that the `.ts` files have no compiled `.js` file alongside it


### PR DESCRIPTION
`%example` strings and multiline jsons in the entity description for integrations like telegram, logitech media server, and frigate caused the generated types file to be invalid, as they were being treated as entity properties

There was no output, because bundled-in prettier step was failing the script before it had the chance to save it to the file. Removed built-in prettier as I don't see linting as a priority when it can prevent the output of the types file (at least you can fix it manually when it's there), and the user can run their linter if it wants.