### PR TITLE
TriggerCard updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,16 @@
-# @hakit/core
+# @hakit/components
+## 1.0.24
+- TriggerCard - wide range of new props to make this card more configurable, previously this card was updated automatically based on the last updated or last triggered value, now it will deactivate after a period of time, there's also description, icon changes, text changes props and more, see storybook for more details.
 
+# @hakit/core
+## 1.0.21
+- entity.custom now has a timeDiff property available in milliseconds representing the time difference between now and the last updated time of the entity.
+# @hakit/core
 ## 1.0.20
 
 ### Patch Changes
-
 - Fixing bug with api types on snake domains, previously useEntity('media_player').api was not returning available services
 # @hakit/components
-
 ## 1.0.23
 - bumping dependency version
 # @hakit/core

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hakit/components",
   "type": "module",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "private": false,
   "keywords": [
     "react",
@@ -67,7 +67,7 @@
   "peerDependencies": {
     "@emotion/react": ">=10.x",
     "@emotion/styled": ">=10.x",
-    "@hakit/core": "^1.0.20",
+    "@hakit/core": "^1.0.21",
     "@use-gesture/react": ">=10.x",
     "framer-motion": ">=10.x",
     "lodash": ">=4.x",

--- a/packages/components/src/Cards/ButtonCard/index.tsx
+++ b/packages/components/src/Cards/ButtonCard/index.tsx
@@ -175,7 +175,6 @@ export interface ButtonCardProps<E extends EntityName> extends Extendable {
   /** the layout of the button card, this changes slightly, just preferences really @default default */
   defaultLayout?: "default" | "slim";
 }
-/** The ButtonCard component is an easy way to represent the state and control of an entity with a simple button, eventually I'll provide further options per domain, like being able to set the colours for lights etc... */
 function _ButtonCard<E extends EntityName>({
   service,
   entity: _entity,
@@ -335,7 +334,7 @@ function _ButtonCard<E extends EntityName>({
     </>
   );
 }
-
+/** The ButtonCard component is an easy way to represent the state and control of an entity with a simple button, eventually I'll provide further options per domain, like being able to set the colours for lights etc... */
 export function ButtonCard<E extends EntityName>(props: ButtonCardProps<E>) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ButtonCard" })}>

--- a/packages/components/src/Cards/ClimateCard/index.tsx
+++ b/packages/components/src/Cards/ClimateCard/index.tsx
@@ -80,7 +80,6 @@ export interface ClimateCardProps extends Extendable {
   onClick?: (entity: HassEntityWithApi<"climate">) => void;
 }
 
-/** The ClimateCard is a card to easily interact with climate entities, whilst it's not documented below, the types are correct and you can also pass through anything related to ModalClimateControlsProps */
 function _ClimateCard({
   entity: _entity,
   title: _title,
@@ -197,6 +196,7 @@ function _ClimateCard({
     </>
   );
 }
+/** The ClimateCard is a card to easily interact with climate entities, whilst it's not documented below, the types are correct and you can also pass through anything related to ModalClimateControlsProps */
 export function ClimateCard(props: ClimateCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ClimateCard" })}>

--- a/packages/components/src/Cards/EntitiesCard/index.tsx
+++ b/packages/components/src/Cards/EntitiesCard/index.tsx
@@ -146,7 +146,6 @@ export interface EntitiesCardProps extends Extendable {
   /** include the last updated time, will apply to every row unless specified on an individual EntityItem @default false */
   includeLastUpdated?: boolean;
 }
-/** The EntitiesCard component is an easy way to represent the state a of multiple entities with a simple layout, you can customize every part of every row with the EntityItem properties, the renderState and onClick both receive the entity object with the api properties. */
 function _EntitiesCard({
   entities,
   includeLastUpdated = false,
@@ -172,7 +171,7 @@ function _EntitiesCard({
     </StyledEntitiesCard>
   );
 }
-
+/** The EntitiesCard component is an easy way to represent the state a of multiple entities with a simple layout, you can customize every part of every row with the EntityItem properties, the renderState and onClick both receive the entity object with the api properties. */
 export function EntitiesCard(props: EntitiesCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "EntitiesCard" })}>

--- a/packages/components/src/Cards/FabCard/index.tsx
+++ b/packages/components/src/Cards/FabCard/index.tsx
@@ -85,7 +85,6 @@ export interface FabCardProps<E extends EntityName> extends Extendable {
   disabled?: boolean;
 }
 
-/** The Fab (Floating Action Button) Card is a simple button with an icon to trigger something on press */
 function _FabCard<E extends EntityName>({
   icon: _icon,
   iconColor,
@@ -183,7 +182,7 @@ function _FabCard<E extends EntityName>({
     </>
   );
 }
-
+/** The Fab (Floating Action Button) Card is a simple button with an icon to trigger something on press */
 export function FabCard<E extends EntityName>(props: FabCardProps<E>) {
   return (
     <ErrorBoundary {...fallback({ prefix: "FabCard" })}>

--- a/packages/components/src/Cards/PictureCard/index.tsx
+++ b/packages/components/src/Cards/PictureCard/index.tsx
@@ -61,7 +61,6 @@ const PictureCardFooter = styled(motion.h4)`
   font-size: 1.2rem;
 `;
 
-/** A simple component to render an image with a title/icon similar to the lovelace picture card, you can also bind a click event to the card */
 function _PictureCard({
   onClick,
   title,
@@ -87,7 +86,7 @@ function _PictureCard({
     </StyledPictureCard>
   );
 }
-
+/** A simple component to render an image with a title/icon similar to the lovelace picture card, you can also bind a click event to the card */
 export function PictureCard(props: PictureCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "PictureCard" })}>

--- a/packages/components/src/Cards/RoomCard/index.tsx
+++ b/packages/components/src/Cards/RoomCard/index.tsx
@@ -103,7 +103,6 @@ const ChildContainer = styled(motion.div)`
   width: 100%;
 `;
 
-/** The RoomCard component is a very simple way of categorizing all your entities into a single "PictureCard" which will show all the entities when clicked. */
 function _RoomCard({
   hash,
   children,
@@ -266,7 +265,7 @@ function _RoomCard({
     </>
   );
 }
-
+/** The RoomCard component is a very simple way of categorizing all your entities into a single "PictureCard" which will show all the entities when clicked. */
 export function RoomCard(props: RoomCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "RoomCard" })}>

--- a/packages/components/src/Cards/SidebarCard/index.tsx
+++ b/packages/components/src/Cards/SidebarCard/index.tsx
@@ -210,7 +210,6 @@ export interface MenuItem {
   onClick: (event: React.MouseEvent<HTMLLIElement>) => void;
 }
 
-/** This component is a nice way of organizing components / groups into an easy to navigate sidebar, the "Room Cards" will automatically insert into the sidebar items if they're present on the page, eg if you have 6 RoomCards, all 6 items will be added to the sidebar automatically, you can also add your own menu items to the start of the list, this all needs a bit more thought but for now it is pretty useful! The TimeCard and WeatherCard are integrate and themed slightly different in the sidebar, if the sidebar is present, the RoomCard will only expand to the available space and not cover the sidebar */
 export interface SidebarCardProps {
   /** should the time card be included by default @default true */
   includeTimeCard?: boolean;
@@ -398,7 +397,7 @@ function _SidebarCard({
     </>
   );
 }
-
+/** This component is a nice way of organizing components / groups into an easy to navigate sidebar, the "Room Cards" will automatically insert into the sidebar items if they're present on the page, eg if you have 6 RoomCards, all 6 items will be added to the sidebar automatically, you can also add your own menu items to the start of the list, this all needs a bit more thought but for now it is pretty useful! The TimeCard and WeatherCard are integrate and themed slightly different in the sidebar, if the sidebar is present, the RoomCard will only expand to the available space and not cover the sidebar */
 export function SidebarCard(props: SidebarCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "SidebarCard" })}>

--- a/packages/components/src/Cards/TimeCard/index.tsx
+++ b/packages/components/src/Cards/TimeCard/index.tsx
@@ -138,7 +138,6 @@ const Warning = () => (
     </p>
   </Alert>
 );
-/** There's no required props on this component, by default it retrieves information from the time and date sensor from your home assistant information and the dates are formatted by the timezone specified in your home assistant settings. */
 function _TimeCard({
   includeDate = true,
   includeIcon = true,
@@ -190,7 +189,7 @@ function _TimeCard({
     </Card>
   );
 }
-
+/** There's no required props on this component, by default it retrieves information from the time and date sensor from your home assistant information and the dates are formatted by the timezone specified in your home assistant settings. */
 export function TimeCard(props: TimeCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "TimeCard" })}>

--- a/packages/components/src/Cards/TriggerCard/TriggerCard.stories.tsx
+++ b/packages/components/src/Cards/TriggerCard/TriggerCard.stories.tsx
@@ -15,6 +15,18 @@ function Render(args?: Args) {
           }}
         />
         <TriggerCard
+          entity="automation.dim_lights"
+          description="Will dim all the lights linked to the automation"
+          sliderIcon="mdi:downlight"
+          sliderTextActive="Dimming..."
+          sliderTextInactive="Dim me!"
+          hideArrow
+          {...args}
+          onClick={(entity) => {
+            entity.api.turnOn();
+          }}
+        />
+        <TriggerCard
           entity="light.unavailable"
           onClick={(entity) => {
             // will not fire when unavailable
@@ -42,6 +54,6 @@ export type Story = StoryObj<typeof TriggerCard>;
 export const Example: Story = {
   render: Render,
   args: {
-    entity: "scene.good_morning",
+    
   },
 };

--- a/packages/components/src/Cards/TriggerCard/index.tsx
+++ b/packages/components/src/Cards/TriggerCard/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, useRef, useState } from "react";
 import styled from "@emotion/styled";
 import type { EntityName, ExtractDomain, HassEntityWithApi } from "@hakit/core";
 import {
@@ -47,19 +47,20 @@ const ToggleMessage = styled.span<ToggleProps>`
   align-items: center;
   justify-content: flex-end;
   height: 100%;
-  padding: 0 6px 0 8px;
+  padding: 0 0.4rem 0 0.8rem;
   transition: var(--ha-transition-duration) var(--ha-easing);
   transition-property: justify-content, color;
   justify-content: ${(props) => (props.active ? `flex-start` : `flex-end`)};
   color: ${(props) =>
     !props.active ? "var(--ha-secondary-color)" : "var(--ha-primary-inactive)"};
+    ${props => props.hideArrow && `padding-right: 0.8rem;`}
 `;
 
 const ToggleState = styled.div<ToggleProps>`
   background-color: white;
   border-radius: 100%;
-  width: 30px;
-  height: 30px;
+  width: 1.9rem;
+  height: 1.9rem;
   position: absolute;
   top: 5px;
   left: 0px;
@@ -82,6 +83,7 @@ const ToggleState = styled.div<ToggleProps>`
 
 interface ToggleProps {
   active: boolean;
+  hideArrow?: boolean;
 }
 const Gap = styled.div`
   height: 20px;
@@ -90,13 +92,13 @@ const Toggle = styled.div<ToggleProps>`
   position: relative;
   background-color: ${(props) =>
     props.active ? "var(--ha-primary-active)" : "var(--ha-secondary-inactive)"};
-  border-radius: 30px;
-  width: 120px;
-  height: 40px;
+  border-radius: 3rem;
+  width: 10rem;
+  height: 2.5rem;
   flex-grow: 0;
   flex-shrink: 0;
   transition: background-color var(--ha-transition-duration) var(--ha-easing);
-  margin-left: 20px;
+  margin-left: 1.5rem;
   overflow: hidden;
 `;
 
@@ -117,30 +119,62 @@ const Description = styled.div<{
   color: var(--ha-primary-active);
   ${(props) => props.disabled && `color: var(--ha-secondary-color);`}
   font-size: 0.9rem;
+  span {
+    display: block;
+    width: 100%;
+    color: var(--ha-secondary-color);
+    margin-top: 0.3rem;
+    line-height: 1rem;
+    font-size: 0.7rem;
+  }
 `;
 type Extendable = MotionProps &
   Omit<React.ComponentPropsWithoutRef<"button">, "title" | "onClick">;
 export interface TriggerCardProps<E extends EntityName> extends Extendable {
   /** An optional override for the title */
   title?: string;
+  /** an optional description to add to the card */
+  description?: string;
   /** The name of your entity */
   entity: E;
   /** the onClick handler is called when the card is pressed  */
   onClick?: (entity: HassEntityWithApi<ExtractDomain<E>>) => void;
+  /** optional override to replace the icon that appears in the card */
+  icon?: string;
+  /** optional override for the slider icon */
+  sliderIcon?: string;
+  /** override for the slider text when the state is active @default "Success..." */
+  sliderTextActive?: string;
+  /** override for the slider text when the state is active @default "Run {domain}" */
+  sliderTextInactive?: string;
+  /** how much time in milliseconds must pass before the active state reverts to it's default state @default 5000 */
+  activeStateDuration?: number;
+  /** display the arrow icon in the slider @default false */
+  hideArrow?: boolean;
 }
 
-/** The TriggerCard is a simple to use component to make it easy to trigger and a scene, automation, script or any other entity to trigger. */
 function _TriggerCard<E extends EntityName>({
   entity: _entity,
   title,
+  description,
   onClick,
   disabled: _disabled,
+  icon: _icon,
+  sliderIcon: _sliderIcon,
+  sliderTextActive,
+  sliderTextInactive,
+  activeStateDuration = 5000,
+  hideArrow = false,
   ...rest
 }: TriggerCardProps<E>): JSX.Element {
   const domain = computeDomain(_entity);
   const entity = useEntity(_entity);
   const entityIcon = useIconByEntity(_entity);
   const domainIcon = useIconByDomain(domain);
+  const timeRef = useRef<NodeJS.Timeout | null>(null);
+  const [active, setActive] = useState(false);
+  const icon = useIcon(_icon ?? null);
+  const sliderIcon = useIcon(_sliderIcon ?? null);
   const powerIcon = useIcon("mdi:power");
   const arrowIcon = useIcon("mingcute:arrows-right-line", {
     style: {
@@ -150,8 +184,14 @@ function _TriggerCard<E extends EntityName>({
   const isUnavailable = isUnavailableState(entity.state);
   const disabled = _disabled || isUnavailable;
   const useApiHandler = useCallback(() => {
+    setActive(true);
     if (typeof onClick === "function" && !isUnavailable) onClick(entity);
-  }, [entity, onClick, isUnavailable]);
+    if (timeRef.current) clearTimeout(timeRef.current);
+    timeRef.current = setTimeout(() => {
+      console.log('resetting');
+      setActive(false);
+    }, activeStateDuration)
+  }, [entity, onClick, activeStateDuration, isUnavailable]);
 
   return (
     <Ripples
@@ -163,8 +203,9 @@ function _TriggerCard<E extends EntityName>({
         <LayoutBetween>
           <Description disabled={disabled}>
             {title || entity.attributes.friendly_name || _entity}
+            {description && <span>{description}</span>}
           </Description>
-          {entityIcon || domainIcon}
+          {icon ?? entityIcon ?? domainIcon}
         </LayoutBetween>
         <Gap />
         <LayoutBetween>
@@ -172,15 +213,15 @@ function _TriggerCard<E extends EntityName>({
             {entity.custom.relativeTime}
             {disabled ? ` - ${entity.state}` : ""}
           </Title>
-          <Toggle active={disabled ? false : entity.custom.active}>
+          <Toggle active={disabled ? false : active}>
             {disabled ? null : (
               <>
-                <ToggleState active={entity.custom.active}>
-                  {powerIcon}
+                <ToggleState active={active}>
+                  {sliderIcon ?? powerIcon}
                 </ToggleState>
-                <ToggleMessage active={entity.custom.active}>
-                  {entity.custom.active ? "Success..." : `Start ${domain}`}{" "}
-                  {!entity.custom.active && arrowIcon}
+                <ToggleMessage hideArrow={hideArrow} active={active}>
+                  {active ? sliderTextActive ?? "Success..." : sliderTextInactive ?? `Run ${domain}`}{" "}
+                  {!active && !hideArrow && arrowIcon}
                 </ToggleMessage>
               </>
             )}
@@ -190,7 +231,7 @@ function _TriggerCard<E extends EntityName>({
     </Ripples>
   );
 }
-
+/** The TriggerCard is a simple to use component to make it easy to trigger and a scene, automation, script or any other entity to trigger. */
 export function TriggerCard<E extends EntityName>(props: TriggerCardProps<E>) {
   return (
     <ErrorBoundary {...fallback({ prefix: "TriggerCard" })}>

--- a/packages/components/src/Cards/TriggerCard/index.tsx
+++ b/packages/components/src/Cards/TriggerCard/index.tsx
@@ -188,9 +188,8 @@ function _TriggerCard<E extends EntityName>({
     if (typeof onClick === "function" && !isUnavailable) onClick(entity);
     if (timeRef.current) clearTimeout(timeRef.current);
     timeRef.current = setTimeout(() => {
-      console.log('resetting');
       setActive(false);
-    }, activeStateDuration)
+    }, activeStateDuration);
   }, [entity, onClick, activeStateDuration, isUnavailable]);
 
   return (

--- a/packages/components/src/Cards/WeatherCard/index.tsx
+++ b/packages/components/src/Cards/WeatherCard/index.tsx
@@ -146,7 +146,6 @@ export interface WeatherCardProps extends Extendable {
   /** include the current forecast row, @default true */
   includeCurrent?: boolean;
 }
-/** This will pull information from the weather entity provided to display the forecast provided by home assistant, this card will display exactly what the weather card in lovelace displays. */
 function _WeatherCard({
   entity,
   title,
@@ -223,7 +222,7 @@ function _WeatherCard({
     </Card>
   );
 }
-
+/** This will pull information from the weather entity provided to display the forecast provided by home assistant, this card will display exactly what the weather card in lovelace displays. */
 export function WeatherCard(props: WeatherCardProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "WeatherCard" })}>

--- a/packages/components/src/Group/index.tsx
+++ b/packages/components/src/Group/index.tsx
@@ -45,7 +45,6 @@ export interface GroupProps extends Omit<React.ComponentProps<"div">, "title"> {
   /** should the group be collapsed by default @default false */
   collapsed?: boolean;
 }
-/** The group component will automatically layout the children in a row with a predefined gap between the children. The Group component is handy when you want to be able to collapse sections of cards */
 function _Group({
   title,
   children,
@@ -92,7 +91,7 @@ function _Group({
     </StyledGroup>
   );
 }
-
+/** The group component will automatically layout the children in a row with a predefined gap between the children. The Group component is handy when you want to be able to collapse sections of cards */
 export function Group(props: GroupProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "Group" })}>

--- a/packages/components/src/Shared/ClimateControls/index.tsx
+++ b/packages/components/src/Shared/ClimateControls/index.tsx
@@ -110,7 +110,6 @@ const FanMode = styled(FabCard)<{
   animation-iteration-count: infinite;
   animation-timing-function: linear;
 `;
-/** This layout is shared for the popup for a buttonCard and fabCard when long pressing on a card with a climate entity, and also the climateCard, this will fill the width/height of the parent component */
 function _ClimateControls({
   entity: _entity,
   hvacModes,
@@ -234,7 +233,7 @@ function _ClimateControls({
     </Column>
   );
 }
-
+/** This layout is shared for the popup for a buttonCard and fabCard when long pressing on a card with a climate entity, and also the climateCard, this will fill the width/height of the parent component */
 export function ClimateControls(props: ClimateControlsProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ClimateControls" })}>

--- a/packages/components/src/Shared/ColorPicker/index.tsx
+++ b/packages/components/src/Shared/ColorPicker/index.tsx
@@ -199,7 +199,6 @@ export interface ColorPickerProps {
   /** will provide the color output as it's changing but not actually finished updating, the value may also trigger initially once the color calculations have been applied */
   onChange?: (colors: ColorPickerOutputColors) => void;
 }
-/** This color picker was designed to easily retrieve a value from a color wheel based on values provided from a light entity, you can click or drag on the picker to pick a value, once applied the color wheel will automatically update your light entity, if the light entity provided does not support color it will not render at all */
 function _ColorPicker({
   disabled = false,
   entity: _entity,
@@ -602,6 +601,7 @@ function _ColorPicker({
   ) : null;
 }
 
+/** This color picker was designed to easily retrieve a value from a color wheel based on values provided from a light entity, you can click or drag on the picker to pick a value, once applied the color wheel will automatically update your light entity, if the light entity provided does not support color it will not render at all */
 export function ColorPicker(props: ColorPickerProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ColorPicker" })}>

--- a/packages/components/src/Shared/ColorTempPicker/index.tsx
+++ b/packages/components/src/Shared/ColorTempPicker/index.tsx
@@ -159,7 +159,6 @@ function drawColorWheel(
   }
 }
 
-/** This color picker was designed to easily retrieve a value from a colour wheel based on values provided from a light entity, you can click or drag on the picker to pick a value */
 function _ColorTempPicker({
   disabled = false,
   entity: _entity,
@@ -424,6 +423,7 @@ function _ColorTempPicker({
   ) : null;
 }
 
+/** This color picker was designed to easily retrieve a value from a colour wheel based on values provided from a light entity, you can click or drag on the picker to pick a value */
 export function ColorTempPicker(props: ColorTempPickerProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ColorTempPicker" })}>

--- a/packages/components/src/Shared/ControlSlider/index.tsx
+++ b/packages/components/src/Shared/ControlSlider/index.tsx
@@ -232,7 +232,6 @@ const SliderHolder = styled.div``;
 const SliderTrackBackground = styled.div``;
 const SliderTrackBar = styled.div``;
 
-/** A interactive slider to control values ranging between two other values, eg brightness on a light, or curtain position etc.. */
 function _ControlSlider({
   vertical = true,
   disabled = false,
@@ -426,6 +425,7 @@ function _ControlSlider({
   );
 }
 
+/** A interactive slider to control values ranging between two other values, eg brightness on a light, or curtain position etc.. */
 export function ControlSlider(props: ControlSliderProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ControlSlider" })}>

--- a/packages/components/src/Shared/Modal/index.tsx
+++ b/packages/components/src/Shared/Modal/index.tsx
@@ -78,7 +78,6 @@ export interface ModalProps {
   /** triggered when the users pressed the close button, this is also triggered when the escape key is pressed */
   onClose: () => void;
 }
-/** The modal component was built to easily generate a popup dialog from any element by passing through an "open" value, if you pass an id value, and the same id value is used on another motion element from framer-motion the Modal will animate from this element, see the examples below. */
 function _Modal({ open, id, title, children, onClose }: ModalProps) {
   const [isPressed] = useKeyPress((event) => event.key === "Escape");
   useEffect(() => {
@@ -129,7 +128,7 @@ function _Modal({ open, id, title, children, onClose }: ModalProps) {
     document.body,
   );
 }
-
+/** The modal component was built to easily generate a popup dialog from any element by passing through an "open" value, if you pass an id value, and the same id value is used on another motion element from framer-motion the Modal will animate from this element, see the examples below. */
 export function Modal(props: ModalProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "Modal" })}>

--- a/packages/components/src/Shared/Ripples/index.tsx
+++ b/packages/components/src/Shared/Ripples/index.tsx
@@ -55,7 +55,6 @@ const ParentRipple = styled.div<{
     display: inline-flex;
   `}
 `;
-/** Ripples is a component that can easily add an interactive ripple effect when clicked, simply wrap your component in Ripples and you're good to go! If your component has a border radius, simply pass the same value as a prop to ripples to mask the effect */
 const _Ripples = memo(
   ({
     duration = 600,
@@ -141,7 +140,7 @@ const _Ripples = memo(
     );
   },
 );
-
+/** Ripples is a component that can easily add an interactive ripple effect when clicked, simply wrap your component in Ripples and you're good to go! If your component has a border radius, simply pass the same value as a prop to ripples to mask the effect */
 export function Ripples(props: RipplesProps) {
   return (
     <ErrorBoundary {...fallback({ prefix: "Ripples" })}>

--- a/packages/components/src/ThemeProvider/index.tsx
+++ b/packages/components/src/ThemeProvider/index.tsx
@@ -14,7 +14,6 @@ export interface ThemeProviderProps<T extends object> {
   theme?: DeepPartial<ThemeParams> & T;
 }
 
-/** A simple way of creating global styles and providing re-usable css variables to re-use across your application */
 function _ThemeProvider<T extends object>({
   theme,
 }: ThemeProviderProps<T>): JSX.Element {
@@ -80,7 +79,7 @@ function _ThemeProvider<T extends object>({
     </>
   );
 }
-
+/** A simple way of creating global styles and providing re-usable css variables to re-use across your application */
 export function ThemeProvider<T extends object>(props: ThemeProviderProps<T>) {
   return (
     <ErrorBoundary {...fallback({ prefix: "ThemeProvider" })}>

--- a/packages/core/mocks/createAutomation.ts
+++ b/packages/core/mocks/createAutomation.ts
@@ -1,0 +1,27 @@
+import { HassEntity } from 'home-assistant-js-websocket';
+import { createEntity } from './createEntity';
+
+const now = new Date();
+
+const defaults = {
+  entity_id: "automation.dim_lights",
+    state: "on",
+    attributes: {
+        id: "1660460668213",
+        last_triggered: new Date(now.setHours(-100)).toISOString(),
+        mode: "single",
+        current: 0,
+        friendly_name: "Dim Lights"
+    },
+    context: {
+      id: "01H989071CWR02B5HG861JXWCC",
+      parent_id: null,
+      user_id: null,
+    },
+    last_changed: now.toISOString(),
+    last_updated: now.toISOString(),
+} satisfies HassEntity;
+
+export const createAutomation = (entity_id: string, overrides: Partial<HassEntity> = {}) => {
+  return createEntity(entity_id, defaults, overrides);
+}

--- a/packages/core/mocks/mockEntities.ts
+++ b/packages/core/mocks/mockEntities.ts
@@ -7,6 +7,7 @@ import { createScene } from './createScene';
 import { createWeather } from './createWeather';
 import { createClimate } from './createClimate';
 import { createVacuum } from './createVacuum';
+import { createAutomation } from './createAutomation';
 
 export const entities: HassEntities = {
   ...createLight('light.unavailable', {
@@ -64,4 +65,5 @@ export const entities: HassEntities = {
     }
   }),
   ...createVacuum("vacuum.robot_vacuum"),
+  ...createAutomation("automation.dim_lights"),
 } as const;

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hakit/core",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "private": false,
   "type": "module",
   "keywords": [

--- a/packages/core/src/hooks/useEntity/index.ts
+++ b/packages/core/src/hooks/useEntity/index.ts
@@ -64,9 +64,12 @@ export function useEntity<
   const api = useApi(domain, entity);
 
   const formatEntity = useCallback((entity: HassEntity): HassEntityCustom => {
-    const relativeTime = timeAgo.format(
-      new Date(entity.attributes.last_triggered ?? entity.last_updated),
+    const now = new Date();
+    const then = new Date(
+      entity.attributes.last_triggered ?? entity.last_updated,
     );
+    const relativeTime = timeAgo.format(then);
+    const timeDiff = Math.abs(now.getTime() - then.getTime());
     const active = relativeTime === "just now";
     const {
       hexColor,
@@ -81,6 +84,7 @@ export function useEntity<
       custom: {
         color,
         relativeTime,
+        timeDiff,
         active,
         hexColor,
         rgbColor,

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -44,6 +44,8 @@ export type HassEntityCustom = HassEntity & {
   custom: {
     /** the difference in time between the last updated value and now, eg "1 minute ago, 1 day ago etc, 5 days from now" */
     relativeTime: string;
+    /** the difference in time in milliseconds between now and the time the entity was updated / triggered */
+    timeDiff: number;
     /** if the last updated value was considered "now" */
     active: boolean;
     /** the hexColor value if the entity is a light */
@@ -66,11 +68,11 @@ type HassEntityHelper<T extends AllDomains> =
     : HassEntity;
 
 export type HassEntityWithApi<T extends AllDomains> = HassEntityCustom &
-HassEntityHelper<SnakeToCamel<T>> & {
-  api: SnakeToCamel<T> extends keyof SupportedServices<"no-target">
-    ? SupportedServices<"no-target">[SnakeToCamel<T>]
-    : never;
-};
+  HassEntityHelper<SnakeToCamel<T>> & {
+    api: SnakeToCamel<T> extends keyof SupportedServices<"no-target">
+      ? SupportedServices<"no-target">[SnakeToCamel<T>]
+      : never;
+  };
 
 export type ServiceFunctionWithEntity<Data = object> = (
   /** the entity string name from home assistant */


### PR DESCRIPTION
# @hakit/components
## 1.0.24
- TriggerCard - wide range of new props to make this card more configurable, previously this card was updated automatically based on the last updated or last triggered value, now it will deactivate after a period of time, there's also description, icon changes, text changes props and more, see storybook for more details.

# @hakit/core
## 1.0.21
- entity.custom now has a timeDiff property available in milliseconds representing the time difference between now and the last updated time of the entity.