### PR TITLE
feat: allow breakpoint queries on PersonCard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24720,7 +24720,7 @@
     },
     "packages/components": {
       "name": "@hakit/components",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "devDependencies": {
         "@emotion/babel-plugin": "^11.x",
@@ -24738,7 +24738,7 @@
         "@emotion/react": ">=11.x",
         "@emotion/styled": ">=11.x",
         "@fullcalendar/react": ">=6.x.x",
-        "@hakit/core": "^3.1.3",
+        "@hakit/core": "^3.1.4",
         "@use-gesture/react": ">=10.x",
         "autolinker": ">=4.x",
         "framer-motion": ">=10.x",
@@ -24758,7 +24758,7 @@
     },
     "packages/core": {
       "name": "@hakit/core",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "hakit-sync-types": "dist/sync/cli/cli.js"

--- a/packages/components/src/Cards/FamilyCard/PersonCard.tsx
+++ b/packages/components/src/Cards/FamilyCard/PersonCard.tsx
@@ -1,4 +1,4 @@
-import { CardBase, CardBaseProps, fallback } from "@components";
+import { AvailableQueries, CardBase, CardBaseProps, fallback } from "@components";
 import styled from "@emotion/styled";
 import { EntityName, FilterByDomain, useEntity, useHass, useIcon } from "@hakit/core";
 import { useMemo } from "react";
@@ -178,9 +178,17 @@ function _PersonCard({
 
 /** The PersonCard component is an easy way to represent the state of a person. Can be added as children to the FamilyCard component to quickly give an overview of the whole family. */
 export function PersonCard(props: PersonCardProps) {
+  const defaultColumns: AvailableQueries = {
+    xxs: 12,
+    xs: 6,
+    sm: 6,
+    md: 4,
+    lg: 4,
+    xlg: 3,
+  };
   return (
     <ErrorBoundary {...fallback({ prefix: "PersonCard" })}>
-      <_PersonCard disableColumns {...props} />
+      <_PersonCard {...defaultColumns} {...props} />
     </ErrorBoundary>
   );
 }


### PR DESCRIPTION
Since we decided to go with a compositional approach where we allow PersonCard's as children to the FamilyCard, it makes sense to allow the user to easily change the width of the individual cards on different screen sizes