### PR TITLE
Ensure hover style not retained if focused

### DIFF
--- a/packages/components/src/Cards/ButtonCard/index.tsx
+++ b/packages/components/src/Cards/ButtonCard/index.tsx
@@ -27,7 +27,7 @@ const StyledButtonCard = styled(CardBase)`
   }
   &:not(.disabled),
   &:not(:disabled) {
-    &:hover {
+    &:not(:focus):hover {
       .fab-card-inner {
         background-color: var(--ha-S500);
         color: var(--ha-S500-contrast);

--- a/packages/components/src/Cards/CardBase/index.tsx
+++ b/packages/components/src/Cards/CardBase/index.tsx
@@ -65,8 +65,8 @@ const getMotionElement = (as: ElementType, onlyFunctionality?: boolean) => {
       color: var(--ha-S200-contrast);
       transition: color var(--ha-transition-duration) var(--ha-easing);
     }
-    &:not(:disabled):hover,
-    &:not(.disabled):hover {
+    &:not(:disabled):not(:focus):hover,
+    &:not(.disabled):not(:focus):hover {
       background-color: var(--ha-S400);
       color: var(--ha-500-contrast);
       svg {


### PR DESCRIPTION
Was hitting issues on a tablet where a button was pressed and would retain its hover style after