### PR TITLE
Allow entity modal to accept additional children

### DIFF
--- a/packages/components/src/Shared/Modal/ModalByEntityDomain/index.tsx
+++ b/packages/components/src/Shared/Modal/ModalByEntityDomain/index.tsx
@@ -91,7 +91,7 @@ export type ModalByEntityDomainProps<E extends EntityName> = ModalPropsHelper<Ex
   hideAttributes?: boolean;
   hideLogbook?: boolean;
   stateTitle?: string;
-} & Omit<ModalProps, "children">;
+};
 
 export function ModalByEntityDomain<E extends EntityName>({
   entity,
@@ -99,6 +99,7 @@ export function ModalByEntityDomain<E extends EntityName>({
   hideUpdated,
   hideAttributes,
   hideLogbook = false,
+  children,
   ...rest
 }: ModalByEntityDomainProps<E>) {
   const { joinHassUrl, useStore } = useHass();
@@ -155,7 +156,7 @@ export function ModalByEntityDomain<E extends EntityName>({
     if (!stateRef.current) return;
     stateRef.current.innerText = value;
   }, []);
-  const children = useMemo(() => {
+  const defaultChildren = useMemo(() => {
     switch (domain) {
       case "light":
         return <ModalLightControls entity={entity as FilterByDomain<EntityName, "light">} onStateChange={onStateChange} {...childProps} />;
@@ -262,6 +263,7 @@ export function ModalByEntityDomain<E extends EntityName>({
             </Column>
           )}
           {children}
+          {defaultChildren}
           {!hideAttributes && <EntityAttributes entity={entity} />}
         </>
       )}

--- a/packages/components/src/Shared/Modal/ModalByEntityDomain/index.tsx
+++ b/packages/components/src/Shared/Modal/ModalByEntityDomain/index.tsx
@@ -85,13 +85,18 @@ export type ModalPropsHelper<D extends AllDomains> = D extends keyof ModalPropsB
       entity: EntityName;
     };
 
+// remove children from ModalProps, and make it optional
+type OptionalChildrenModalProps = Omit<ModalProps, "children"> & {
+  children?: React.ReactNode;
+};
+
 export type ModalByEntityDomainProps<E extends EntityName> = ModalPropsHelper<ExtractDomain<E>> & {
   hideState?: boolean;
   hideUpdated?: boolean;
   hideAttributes?: boolean;
   hideLogbook?: boolean;
   stateTitle?: string;
-};
+} & OptionalChildrenModalProps;
 
 export function ModalByEntityDomain<E extends EntityName>({
   entity,
@@ -262,7 +267,7 @@ export function ModalByEntityDomain<E extends EntityName>({
               {!hideUpdated && <Updated className="last-updated">{_entity.custom.relativeTime}</Updated>}
             </Column>
           )}
-          {children}
+          {children ?? null}
           {defaultChildren}
           {!hideAttributes && <EntityAttributes entity={entity} />}
         </>


### PR DESCRIPTION
Added them to the top of the modal, before the default items for the entity type.  Unsure if there's a better way to do this to allow for more customization