### PR TITLE
fix: semantic errors related to import json

### DIFF
--- a/hakit/server/routes/download-version.ts
+++ b/hakit/server/routes/download-version.ts
@@ -6,7 +6,7 @@ import { APP_DIRECTORY } from '../constants.js';
 import { downloadFile, listFilesInFolder } from '../google/drive/index.js';
 import { ensureDirectoryExists, translateError } from '../helpers/index.js';
 import { loadFile } from '../helpers/read-file.js';
-import addonPackage from '../../package.json' assert { type: 'json' };
+import addonPackage from '../../package.json' with { type: 'json' };
 
 export async function downloadVersion(_req: Request, res: Response) {
   // TODO - change download version to download a specific version


### PR DESCRIPTION
As per the [MDN import with spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import/with), the new standard is `with { type: "json" }` instead of `assert { type: "json" }` since node 20.10.0. This cause hakit addon stop working in LTS node and latest homeassistant official image.