### PR TITLE
Feature/181 climate card target step override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# 5.0.1
+
+### @hakit/components
+- FEATURE/BUGFIX - ClimateCard and related components previously had hard coded "step" values when incrementing temperature, now it will use the step value provided by the entity by default, allow you to override the step value or fallback to 0.5 for Celsius and 1 for Fahrenheit
+
+### @hakit/core
+- No changes, bumping version to align with components package.
+
 # 5.0.0
 
 ### Migration from v4 to v5

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hakit/components",
   "type": "module",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": false,
   "keywords": [
     "react",
@@ -69,7 +69,7 @@
     "@emotion/react": ">=11.x.x",
     "@emotion/styled": ">=11.x",
     "@fullcalendar/react": ">=6.x.x",
-    "@hakit/core": "^5.0.0",
+    "@hakit/core": "^5.0.1",
     "@mui/material": "^6.3.0",
     "@use-gesture/react": ">=10.x",
     "autolinker": ">=4.x",

--- a/packages/components/src/Cards/ButtonCard/ButtonCard.stories.tsx
+++ b/packages/components/src/Cards/ButtonCard/ButtonCard.stories.tsx
@@ -103,7 +103,7 @@ function Render(args?: Args) {
     <HassConnect hassUrl="http://localhost:8123">
       <ThemeProvider includeThemeControls />
       <Column gap="1rem" fullWidth>
-        <ButtonCard {...args} />
+        <ButtonCard {...args} description="asdf" />
         <ButtonCard {...args} entity="light.fake_light_1" service="toggle" layoutType="slim" />
         <ButtonCard {...args} entity="cover.cover_position_only" service="toggle" layoutType="slim-vertical" />
         <ButtonCard service="toggle" entity="light.fake_light_1" />

--- a/packages/components/src/Cards/ClimateCard/ClimateCard.stories.tsx
+++ b/packages/components/src/Cards/ClimateCard/ClimateCard.stories.tsx
@@ -23,6 +23,7 @@ function TempRender(args?: Args) {
         <ClimateCard showTemperatureControls entity={"climate.air_conditioner"} {...args} />
         <ClimateCard
           showTemperatureControls
+          targetTempStep={0.5}
           layoutType="slim-vertical"
           hvacModes={["cool", "heat"]}
           entity={"climate.air_conditioner"}

--- a/packages/components/src/Cards/ClimateCard/ClimateCard.stories.tsx
+++ b/packages/components/src/Cards/ClimateCard/ClimateCard.stories.tsx
@@ -24,6 +24,7 @@ function TempRender(args?: Args) {
         <ClimateCard
           showTemperatureControls
           targetTempStep={0.5}
+          title="With 0.5 Step"
           layoutType="slim-vertical"
           hvacModes={["cool", "heat"]}
           entity={"climate.air_conditioner"}

--- a/packages/components/src/Cards/ClimateCard/index.tsx
+++ b/packages/components/src/Cards/ClimateCard/index.tsx
@@ -154,6 +154,7 @@ function InternalClimateCard({
           hideCurrentTemperature,
           hideHvacModes,
           hvacModeLabels,
+          targetTempStep: _step,
           ...modalProps,
         }}
         onClick={() => {

--- a/packages/components/src/Cards/ClimateCard/index.tsx
+++ b/packages/components/src/Cards/ClimateCard/index.tsx
@@ -6,6 +6,7 @@ import { useEntity, OFF, isUnavailableState, useHass, localize } from "@hakit/co
 import { fallback, Row, ButtonBar, Column } from "@components";
 import { capitalize } from "lodash";
 import { icons, activeColors, colors } from "../../Shared/Entity/Climate/ClimateControls/shared";
+import { UNIT_F } from "../../Shared/Entity/Climate/ClimateControls/data";
 import { ErrorBoundary } from "react-error-boundary";
 import type { HassConfig } from "home-assistant-js-websocket";
 import { LocaleKeys } from "@hooks";
@@ -92,6 +93,7 @@ function InternalClimateCard({
   layoutType,
   key,
   title,
+  targetTempStep,
   ...rest
 }: ClimateCardProps): React.ReactNode {
   const { getConfig, useStore } = useHass();
@@ -109,6 +111,7 @@ function InternalClimateCard({
     max_temp = 40,
     unit_of_measurement,
     temperature = 20,
+    target_temp_step,
   } = entity.attributes || {};
   const isOff = entity.state === OFF;
   const titleValue = useMemo(() => {
@@ -120,6 +123,10 @@ function InternalClimateCard({
     }
     return hvac_action ? localize(hvac_action) : localize("unknown");
   }, [hvac_action, isUnavailable, isOff]);
+
+  const _step = useMemo(() => {
+    return targetTempStep ?? target_temp_step ?? (config?.unit_system.temperature === UNIT_F ? 1 : 0.5);
+  }, [config?.unit_system.temperature, targetTempStep, target_temp_step]);
 
   useEffect(() => {
     getConfig().then(setConfig);
@@ -246,7 +253,7 @@ function InternalClimateCard({
                 onClick={() => {
                   entity.service.setTemperature({
                     serviceData: {
-                      temperature: temperature - 1,
+                      temperature: temperature - _step,
                     },
                   });
                 }}
@@ -287,7 +294,7 @@ function InternalClimateCard({
                 onClick={() => {
                   entity.service.setTemperature({
                     serviceData: {
-                      temperature: temperature + 1,
+                      temperature: temperature + _step,
                     },
                   });
                 }}

--- a/packages/components/src/Shared/Entity/Climate/ClimateControls/ClimateControlSlider.tsx
+++ b/packages/components/src/Shared/Entity/Climate/ClimateControls/ClimateControlSlider.tsx
@@ -125,9 +125,10 @@ const Wrapper = styled.div`
 export interface ClimateControlSliderProps {
   entity: FilterByDomain<EntityName, "climate">;
   showCurrent?: boolean;
+  targetTempStep?: number;
 }
 
-export function ClimateControlSlider({ entity: _entity, showCurrent = false }: ClimateControlSliderProps) {
+export function ClimateControlSlider({ entity: _entity, targetTempStep, showCurrent = false }: ClimateControlSliderProps) {
   const [_targetTemperature, setTargetTemperature] = useState<Partial<Record<Target, number>>>({});
   const [_selectTargetTemperature, setSelectTargetTemperature] = useState<Target>("low");
   const entity = useEntity(_entity);
@@ -137,8 +138,8 @@ export function ClimateControlSlider({ entity: _entity, showCurrent = false }: C
   const { min_temp: _min, max_temp: _max, target_temp_step, hvac_modes } = entity.attributes;
 
   const _step = useMemo(() => {
-    return target_temp_step || (config?.unit_system.temperature === UNIT_F ? 1 : 0.5);
-  }, [config?.unit_system.temperature, target_temp_step]);
+    return targetTempStep ?? target_temp_step ?? (config?.unit_system.temperature === UNIT_F ? 1 : 0.5);
+  }, [config?.unit_system.temperature, targetTempStep, target_temp_step]);
 
   useEffect(() => {
     setTargetTemperature({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hakit/core",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "private": false,
   "type": "module",
   "keywords": [


### PR DESCRIPTION
For [issue](https://github.com/shannonhochkins/ha-component-kit/issues/181)

- FEATURE/BUGFIX - ClimateCard and related components previously had hard coded "step" values when incrementing temperature, now it will use the step value provided by the entity by default, allow you to override the step value or fallback to 0.5 for Celsius and 1 for Fahrenheit