### PR TITLE
Removing framer motion on forecast elements, cleaned up updates to ca…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ There's a [Home Assistant Addon](ADDON.md) available which will serve your dashb
 - [TimeCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-timecard--docs)
 - [TriggerCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-triggercard--docs)
 - [WeatherCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-weathercard--docs)
-- [NEW VacuumCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-vacuumcard--docs)
+- [VacuumCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-vacuumcard--docs)
 
 ### Known Issues
 - Anything else? Please, if you notice anything that doesn't feel / look right, please report it, i rely on user testing to make improvements.

--- a/packages/components/src/Cards/WeatherCard/index.tsx
+++ b/packages/components/src/Cards/WeatherCard/index.tsx
@@ -17,7 +17,6 @@ import {
 } from "@components";
 import { ErrorBoundary } from "react-error-boundary";
 import { getAdditionalWeatherInformation } from "./helpers";
-import { motion } from "framer-motion";
 
 const Card = styled(CardBase)``;
 
@@ -90,7 +89,7 @@ function splitForecastsIntoRows<T>(arr: T[], rowCount: number, maxItemsPerRow: n
   return result;
 }
 
-const Forecast = styled(motion.div)`
+const Forecast = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -151,7 +150,7 @@ export interface WeatherCardProps extends Omit<CardBaseProps<"div", FilterByDoma
   allowForecastToggle?: boolean;
 }
 
-const FORECAST_ITEM_PROJECTED_WIDTH = 40;
+const FORECAST_ITEM_PROJECTED_WIDTH = 50;
 
 function InternalWeatherCard({
   entity,
@@ -239,7 +238,7 @@ function InternalWeatherCard({
             const dateFormatted = convertDateTime(forecast.datetime, timeZone);
             const [day, , hour] = dateFormatted.split(",");
             return (
-              <Forecast key={index} className="forecast" layoutId={forecast.datetime}>
+              <Forecast key={index} className="forecast">
                 {includeDay && <Day className="day">{day}</Day>}
                 {includeTime && <Time className="time">{hour}</Time>}
                 <ForecastIcon
@@ -281,7 +280,8 @@ function InternalWeatherCard({
       serviceData={serviceData}
       className={`${className ?? ""} weather-card`}
       resizeDetectorProps={{
-        refreshRate: 500,
+        refreshRate: 50,
+        refreshMode: 'throttle',
         onResize({ width: _width }) {
           if (_width) {
             setWidth(_width);
@@ -350,7 +350,7 @@ function InternalWeatherCard({
             })}
           </Row>
         )}
-        {includeForecast && !isUnavailable && genForecastRows()}
+        {includeForecast && !isUnavailable && width > 0 && genForecastRows()}
         {isUnavailable && weather.state}
       </Contents>
     </Card>


### PR DESCRIPTION
Fixes [issue](https://github.com/shannonhochkins/ha-component-kit/issues/189) 

Changes:
1. Removed framer motion element on forecast columns, this simply isn't a desired feature as the animations hinder rather than aid here.
2. Changed the resize observer to throttle updates rathern than debounce so the updates to the layout are immediate.
3. Reduced throttle time from 500ms to 50ms, I believe this was a typo initially and it shouldn't take this long to update
4. Increased the projected column width from 40px to 50px to give some more room between columns.
5. Will only render the forecast row when there's width detected for the card.