### PR TITLE
Disabling scale effect by default for all popups

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import { withThemeFromJSXProvider } from '@storybook/addon-themes';
 import { ThemeProvider } from '@storybook/theming';
 import { Page } from "./page";
+import { redirectToStory } from './redirect';
 import './global.css';
 
 
@@ -14,6 +15,7 @@ const theme = {
     }
   }
 };
+
 
 
 export default {
@@ -31,7 +33,7 @@ export default {
       // so we redirect from one story to another
       if (args.parameters.redirectTo) {
         if (window.top) {
-          window.top.location.href = args.parameters.redirectTo;
+          redirectToStory(args.parameters.redirectTo);
         }
       }
       const centered = args.parameters.centered ? {

--- a/.storybook/redirect.ts
+++ b/.storybook/redirect.ts
@@ -1,0 +1,10 @@
+
+
+export function redirectToStory(pathQueryString: string) {
+  if (window.top) {
+    // with the window top location, we need to update the `path` query string value (if present) and then redirect to this new url
+    const url = new URL(window.top.location.href);
+    url.searchParams.set('path', pathQueryString);
+    window.top.location.href = url.toString();
+  }
+}

--- a/hass-connect-fake/index.tsx
+++ b/hass-connect-fake/index.tsx
@@ -4,7 +4,6 @@ import {
   useRef,
   useEffect,
   type ReactNode,
-  type ReactElement,
 } from "react";
 import type {
   HassEntities,
@@ -37,7 +36,7 @@ import { logs } from './mocks/mockLogs';
 import {dailyForecast, hourlyForecast} from './mocks/mockWeather';
 
 interface HassProviderProps {
-  children: (ready: boolean) => ReactElement<HTMLElement | ReactNode> | ReactNode;
+  children: (ready: boolean) => ReactNode;
   hassUrl: string;
   throttle?: number;
 }
@@ -561,7 +560,7 @@ export const HassConnect = ({
   children,
   hassUrl,
   fallback,
-}: HassConnectProps): ReactElement<HTMLElement | ReactNode> => {
+}: HassConnectProps): ReactNode => {
   return (
     <HassProvider hassUrl={hassUrl}>
       {(ready) => (ready ? children : (fallback ?? null))}

--- a/hass-connect-fake/mocks/fake-call-service/mediaPlayer.ts
+++ b/hass-connect-fake/mocks/fake-call-service/mediaPlayer.ts
@@ -58,109 +58,111 @@ export function mediaPlayerUpdates({
     last_changed: now,
     last_updated: now,
   }
-  if (typeof _target === 'string') return true;
-  const [target] = _target;
-  switch (service) {
-    case 'mediaPlay':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...dates,
-          state: 'playing'
-        }
-      }));
-    case 'turnOn':
-    case 'turn_on':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...tracks(now).first,
-          ...dates,
-          state: 'playing'
-        }
-      }));
-    case 'turnOff':
-    case 'turn_off':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...dates,
-          state: 'off'
-        }
-      }));
-    case 'mediaPause':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...dates,
-          state: 'paused'
-        }
-      }));
-    case 'mediaPreviousTrack':
-    case 'mediaNextTrack': {
-      return setEntities(entities => {
-        const entity = entities[target];
-        const id = entity.context.id;
-        const next = id === '1' ? 'second' : 'first';
-        return {
+  const targets = typeof _target === 'string' ? [_target] : _target;
+  targets.forEach(target => {
+    switch (service) {
+      case 'mediaPlay':
+        return setEntities(entities => ({
           ...entities,
           [target]: {
             ...entities[target],
-            ...tracks(now)[next],
             ...dates,
-            state: 'playing',
-            attributes: {
-              ...entities[target].attributes,
-              ...tracks(now)[next].attributes,
+            state: 'playing'
+          }
+        }));
+      case 'turnOn':
+      case 'turn_on':
+        return setEntities(entities => ({
+          ...entities,
+          [target]: {
+            ...entities[target],
+            ...tracks(now).first,
+            ...dates,
+            state: 'playing'
+          }
+        }));
+      case 'turnOff':
+      case 'turn_off':
+        return setEntities(entities => ({
+          ...entities,
+          [target]: {
+            ...entities[target],
+            ...dates,
+            state: 'off'
+          }
+        }));
+      case 'mediaPause':
+        return setEntities(entities => ({
+          ...entities,
+          [target]: {
+            ...entities[target],
+            ...dates,
+            state: 'paused'
+          }
+        }));
+      case 'mediaPreviousTrack':
+      case 'mediaNextTrack': {
+        return setEntities(entities => {
+          const entity = entities[target];
+          const id = entity.context.id;
+          const next = id === '1' ? 'second' : 'first';
+          return {
+            ...entities,
+            [target]: {
+              ...entities[target],
+              ...tracks(now)[next],
+              ...dates,
+              state: 'playing',
+              attributes: {
+                ...entities[target].attributes,
+                ...tracks(now)[next].attributes,
+              }
             }
           }
-        }
-      });
-    }
-    case 'mediaSeek':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...dates,
-          attributes: {
-            ...entities[target].attributes,
-            // @ts-ignore - TODO - type later
-            media_position: serviceData?.seek_position,
-            media_position_updated_at: now,
+        });
+      }
+      case 'mediaSeek':
+        return setEntities(entities => ({
+          ...entities,
+          [target]: {
+            ...entities[target],
+            ...dates,
+            attributes: {
+              ...entities[target].attributes,
+              // @ts-ignore - TODO - type later
+              media_position: serviceData?.seek_position,
+              media_position_updated_at: now,
+            }
           }
-        }
-      }));
-    case 'volumeSet':
-    case 'volumeMute':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...dates,
-          attributes: {
-            ...entities[target].attributes,
-            ...serviceData ?? {},            
+        }));
+      case 'volumeSet':
+      case 'volumeMute':
+        return setEntities(entities => ({
+          ...entities,
+          [target]: {
+            ...entities[target],
+            ...dates,
+            attributes: {
+              ...entities[target].attributes,
+              ...serviceData ?? {},            
+            }
           }
-        }
-      }));
-    case 'volumeUp':
-    case 'volumeDown':
-      return setEntities(entities => ({
-        ...entities,
-        [target]: {
-          ...entities[target],
-          ...dates,
-          attributes: {
-            ...entities[target].attributes,
-            volume_level: entities[target].attributes.volume_level + (service === 'volumeUp' ? 0.1 : -0.1),
+        }));
+      case 'volumeUp':
+      case 'volumeDown':
+        return setEntities(entities => ({
+          ...entities,
+          [target]: {
+            ...entities[target],
+            ...dates,
+            attributes: {
+              ...entities[target].attributes,
+              volume_level: entities[target].attributes.volume_level + (service === 'volumeUp' ? 0.1 : -0.1),
+            }
           }
-        }
-      }));
-  }
+        }));
+   }
+  });
+
   return true;
 }

--- a/packages/components/src/Cards/AreaCard/index.tsx
+++ b/packages/components/src/Cards/AreaCard/index.tsx
@@ -108,7 +108,6 @@ const ChildContainer = styled.div`
   flex-direction: column;
 `;
 
-
 function InternalAreaCard({
   hash,
   children,
@@ -178,7 +177,7 @@ function InternalAreaCard({
                 className={"full-screen"}
                 initial={{ opacity: 0 }}
                 transition={{
-                  ...transition
+                  ...transition,
                 }}
                 exit={{
                   opacity: 0,

--- a/packages/components/src/Cards/AreaCard/index.tsx
+++ b/packages/components/src/Cards/AreaCard/index.tsx
@@ -108,6 +108,7 @@ const ChildContainer = styled.div`
   flex-direction: column;
 `;
 
+
 function InternalAreaCard({
   hash,
   children,
@@ -162,6 +163,10 @@ function InternalAreaCard({
     }
   }, [isPressed, open]);
 
+  const transition = {
+    duration: animationDuration,
+  };
+
   return (
     <>
       {open &&
@@ -170,22 +175,22 @@ function InternalAreaCard({
             {open === true && (
               <FullScreen
                 key={`fullscreen-layout-${idRef}`}
-                layoutId={idRef}
-                id={`${idRef}-expanded`}
                 className={"full-screen"}
                 initial={{ opacity: 0 }}
                 transition={{
-                  duration: animationDuration,
+                  ...transition
                 }}
                 exit={{
                   opacity: 0,
                   transition: {
+                    ...transition,
                     delay: animationDuration,
                   },
                 }}
                 animate={{
                   opacity: 1,
                   transition: {
+                    ...transition,
                     delay: 0,
                   },
                 }}
@@ -225,7 +230,6 @@ function InternalAreaCard({
         disableActiveState
         disableRipples
         id={`${idRef}-area-card`}
-        layoutId={idRef}
         className={`area-card ${className ?? ""}`}
         onClick={() => {
           if (!disable) {

--- a/packages/components/src/Cards/CalendarCard/index.tsx
+++ b/packages/components/src/Cards/CalendarCard/index.tsx
@@ -755,7 +755,7 @@ function InternalCalendarCard({
 /**
  * The CalendarCard is very similar to the home assistant calendar card, with the exception of not having delete/edit event functionality, the preview here contains only a month (the current month) of fake events to preview the functionality
  *
- * This component uses the REST API to retrieve events from home assistant, ensure you've followed the instructions [here](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/hooks-usehass-callapi--docs)
+ * This component uses the REST API to retrieve events from home assistant, ensure you've followed the instructions [here](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-usehass-hass-callapi--docs)
  * */
 export function CalendarCard(props: CalendarCardProps) {
   const defaultColumns: AvailableQueries = {

--- a/packages/components/src/Cards/CardBase/index.tsx
+++ b/packages/components/src/Cards/CardBase/index.tsx
@@ -286,7 +286,6 @@ const CardBaseInternal = function CardBase<T extends ElementType, E extends Enti
   rippleProps,
   disableColumns,
   whileTap,
-  layoutId,
   elRef,
   key,
   relatedEntities,
@@ -451,7 +450,6 @@ const CardBaseInternal = function CardBase<T extends ElementType, E extends Enti
           borderRadius: _borderRadius,
         }}
         whileTap={whileTap ?? { scale: disableScale || disabled || isUnavailable ? 1 : 0.9 }}
-        layoutId={layoutId ?? _id}
         disableActiveState={disableActiveState}
         disabled={isUnavailable || disabled}
         {...bind()}

--- a/packages/components/src/Cards/EntitiesCard/EntitiesCardRow.tsx
+++ b/packages/components/src/Cards/EntitiesCard/EntitiesCardRow.tsx
@@ -14,7 +14,6 @@ import { Icon, type IconProps } from "@iconify/react";
 import { Row, fallback, ModalByEntityDomain, type ModalPropsHelper } from "@components";
 import { ErrorBoundary } from "react-error-boundary";
 import { useState, ReactNode, useId, useMemo, useCallback, lazy, Suspense } from "react";
-import { motion } from "framer-motion";
 import { useLongPress } from "use-long-press";
 import styled from "@emotion/styled";
 import { Connection, HassConfig } from "home-assistant-js-websocket";
@@ -46,7 +45,7 @@ const State = styled.div`
   color: var(--ha-S300-contrast);
 `;
 
-const EntityRowInner = styled(motion.div)`
+const EntityRowInner = styled.div`
   width: 100%;
   padding: 1rem;
   transition: background-color var(--ha-transition-duration) var(--ha-easing);
@@ -130,6 +129,7 @@ function InternalEntitiesCardRow<E extends EntityName>({
   modalProps,
   key,
   includeLastUpdated = false,
+  ...rest
 }: EntitiesCardRowProps<E>) {
   const _id = useId();
   const [openModal, setOpenModal] = useState(false);
@@ -173,7 +173,7 @@ function InternalEntitiesCardRow<E extends EntityName>({
 
   return (
     <>
-      <EntityRowInner key={key} className={`entities-card-row`} layoutId={_id} {...bind()}>
+      <EntityRowInner key={key} className={`entities-card-row`} {...bind()} {...rest}>
         <Row className={`row`} wrap="nowrap" gap="1rem" fullWidth onClick={() => onClick && onClick(entity)}>
           <IconWrapper
             className={`icon-wrapper`}

--- a/packages/components/src/Cards/MediaPlayerCard/AlternateControls.tsx
+++ b/packages/components/src/Cards/MediaPlayerCard/AlternateControls.tsx
@@ -14,7 +14,6 @@ interface AlternateControlsProps extends RowProps {
   disabled: boolean;
   allEntityIds: string[];
   onSpeakerGroupClick: () => void;
-  layoutId: string;
   hideGrouping?: boolean;
 }
 
@@ -23,7 +22,6 @@ export function AlternateControls({
   disabled,
   allEntityIds,
   onSpeakerGroupClick,
-  layoutId,
   hideGrouping = false,
 }: AlternateControlsProps) {
   const entity = useEntity(_entity);
@@ -38,7 +36,6 @@ export function AlternateControls({
     <Row gap="0.5rem" wrap="nowrap" className="row">
       {!hideGrouping && (allEntityIds.length > 1 || groups.length > 0) && (
         <Fab
-          layoutId={layoutId}
           className="speaker-group"
           iconProps={{
             color: `var(--ha-S200-contrast)`,

--- a/packages/components/src/Cards/MediaPlayerCard/VolumeControls/index.tsx
+++ b/packages/components/src/Cards/MediaPlayerCard/VolumeControls/index.tsx
@@ -107,6 +107,7 @@ export function VolumeControls({ entity: _entity, volumeLayout, hideMute, disabl
             disabled={disabled}
             size={DEFAULT_FAB_SIZE}
             icon="mdi:volume-minus"
+            title={`${Number(volume_level) * 100}%`}
             onClick={() =>
               mp.volumeDown({
                 target: allEntityIds ?? _entity,
@@ -124,6 +125,7 @@ export function VolumeControls({ entity: _entity, volumeLayout, hideMute, disabl
             disabled={disabled}
             size={DEFAULT_FAB_SIZE}
             icon="mdi:volume-plus"
+            title={`${Number(volume_level) * 100}%`}
             onClick={() =>
               mp.volumeUp({
                 target: allEntityIds ?? _entity,

--- a/packages/components/src/Cards/MediaPlayerCard/index.tsx
+++ b/packages/components/src/Cards/MediaPlayerCard/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback, useMemo, useState, useId } from "react";
+import { useEffect, useRef, useCallback, useMemo, useState } from "react";
 import { useService, useHass, isUnavailableState, useEntity, OFF, supportsFeatureFromAttributes } from "@hakit/core";
 import { snakeCase, clamp } from "lodash";
 import { useGesture } from "@use-gesture/react";
@@ -198,7 +198,6 @@ function InternalMediaPlayerCard({
   const disabled = isUnavailable || _disabled;
   const seekDisabled = isIdle || isOff || isStandby || buffering || disabled;
   const [isGroupingModalOpen, setIsGroupingModalOpen] = useState(false);
-  const groupingLayoutId = useId();
 
   const updateClock = useCallback(
     (x: number) => {
@@ -371,7 +370,6 @@ function InternalMediaPlayerCard({
                       entity={_entity}
                       disabled={disabled}
                       onSpeakerGroupClick={() => setIsGroupingModalOpen(true)}
-                      layoutId={groupingLayoutId}
                       hideGrouping={hideGrouping}
                     />
                   )}
@@ -414,7 +412,6 @@ function InternalMediaPlayerCard({
                     entity={_entity}
                     disabled={disabled}
                     onSpeakerGroupClick={() => setIsGroupingModalOpen(true)}
-                    layoutId={groupingLayoutId}
                     hideGrouping={hideGrouping}
                   />
                 )}

--- a/packages/components/src/Cards/SidebarCard/index.tsx
+++ b/packages/components/src/Cards/SidebarCard/index.tsx
@@ -392,7 +392,7 @@ function InternalSidebarCard({
             </Row>
             <Divider className="divider" />
             <Menu open={open} className="menu">
-              <AnimatePresence>
+              <AnimatePresence initial={false}>
                 {concatenatedMenuItems.map((item, index) => {
                   return (
                     <motion.li
@@ -419,7 +419,7 @@ function InternalSidebarCard({
             </Menu>
             {children && open && <Filler className="filler">{children}</Filler>}
           </Filler>
-          <AnimatePresence mode="wait">
+          <AnimatePresence mode="wait" initial={false}>
             {weatherCardProps && (
               <motion.div
                 className="weather-wrapper"

--- a/packages/components/src/Cards/WeatherCard/index.tsx
+++ b/packages/components/src/Cards/WeatherCard/index.tsx
@@ -281,7 +281,7 @@ function InternalWeatherCard({
       className={`${className ?? ""} weather-card`}
       resizeDetectorProps={{
         refreshRate: 50,
-        refreshMode: 'throttle',
+        refreshMode: "throttle",
         onResize({ width: _width }) {
           if (_width) {
             setWidth(_width);

--- a/packages/components/src/Shared/Entity/Light/LightControls/index.tsx
+++ b/packages/components/src/Shared/Entity/Light/LightControls/index.tsx
@@ -204,7 +204,7 @@ function InternalLightControls({ entity: _entity, onStateChange }: LightControls
           }}
         />
         {supportsColorTemp || supportsColor || (supportsBrightness && <Separator />)}
-        <AnimatePresence>
+        <AnimatePresence initial={false}>
           {supportsBrightness && <FabCard key={`${_entity}-brightness`} icon="mdi:brightness-6" onClick={() => setControl("brightness")} />}
           {supportsColor && <FabCardColor key={`${_entity}-color`} active={control === "color"} onClick={() => setControl("color")} />}
           {supportsColorTemp && (

--- a/packages/components/src/Shared/Entity/MediaPlayer/MediaPlayerControls/index.tsx
+++ b/packages/components/src/Shared/Entity/MediaPlayer/MediaPlayerControls/index.tsx
@@ -202,6 +202,12 @@ export const MediaPlayerControls = ({
                   disableRipples
                   disableScale
                   disableActiveState
+                  xxs={12}
+                  xs={12}
+                  sm={12}
+                  md={12}
+                  lg={12}
+                  xlg={12}
                   className={`entities-card entities-card-media-controls`}
                 >
                   <ErrorBoundary {...fallback({ prefix: "EntityRow" })}>
@@ -240,7 +246,7 @@ export const MediaPlayerControls = ({
                         {!isOff && (
                           <VolumeControls
                             entity={entity.entity_id as FilterByDomain<EntityName, "media_player">}
-                            volumeLayout={"slider"}
+                            volumeLayout={"buttons"}
                             hideMute={false}
                             disabled={false}
                             layout={"slim"}

--- a/packages/components/src/Shared/Menu/index.tsx
+++ b/packages/components/src/Shared/Menu/index.tsx
@@ -208,7 +208,7 @@ export function Menu({ children, placement = "bottom", items = [], cssStyles, ..
           }
           return child;
         })}
-        <AnimatePresence>
+        <AnimatePresence initial={false}>
           {open && (
             <MenuPopup
               ref={menuRef}

--- a/packages/components/src/Shared/Modal/Modal.stories.tsx
+++ b/packages/components/src/Shared/Modal/Modal.stories.tsx
@@ -217,7 +217,6 @@ function RenderModalProvider() {
   );
 }
 
-
 function Inner() {
   const [open, setOpen] = useState(false);
   const _id = useId();
@@ -246,8 +245,14 @@ function RenderAutoScaleFromSource() {
       <ThemeProvider includeThemeControls />
       <Column gap="1rem" fullWidth>
         <Inner />
-        <p>As shown before, from the trigger motion element or any card, if you add `layoutId` with a uniq id name, and then provide the `id` attribute to the modal of the same value, the modal will open as if it was expanding from the originating source, and will collapse when closing back to the original element too.</p>
-        <p><b>Note: </b>This has a side effect of initial layout animations where the card will animate to a default position initially</p>
+        <p>
+          As shown before, from the trigger motion element or any card, if you add `layoutId` with a uniq id name, and then provide the `id`
+          attribute to the modal of the same value, the modal will open as if it was expanding from the originating source, and will
+          collapse when closing back to the original element too.
+        </p>
+        <p>
+          <b>Note: </b>This has a side effect of initial layout animations where the card will animate to a default position initially
+        </p>
         <Source dark code={jsxToString(Inner())} />
       </Column>
     </HassConnect>

--- a/packages/components/src/Shared/Modal/Modal.stories.tsx
+++ b/packages/components/src/Shared/Modal/Modal.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj, Args } from "@storybook/react";
 import styled from "@emotion/styled";
 import { Source } from "@storybook/blocks";
-import { useState } from "react";
+import { useId, useState } from "react";
 import { ThemeProvider, ButtonCard, Modal, FabCard, Column, Row, ModalProvider } from "@components";
 import { HassConnect } from "@hass-connect-fake";
 import jsxToString from "react-element-to-jsx-string";
@@ -25,15 +25,14 @@ const P = styled.p`
 
 const exampleSetup = `
 import { Modal } from '@hakit/components';
-import { useState, useId } from 'react';
+import { useState } from 'react';
 function CustomButton() {
-  const _id = useId();
   const [open, setOpen] = useState(false);
   return (
     <>
       <-- The trigger element can be any motion element, in this case we use a FabCard which is a motion.button element -->
-      <FabCard layoutId={_id} onClick={() => setOpen(true)} icon="mdi:cog" />
-      <Modal id={_id} open={open} title="Settings" onClose={() => {
+      <FabCard onClick={() => setOpen(true)} icon="mdi:cog" />
+      <Modal open={open} title="Settings" onClose={() => {
         setOpen(false);
       }}>
         Add your settings here!
@@ -81,9 +80,8 @@ function RenderCustom() {
       <ThemeProvider includeThemeControls />
       <Column gap="1rem" fullWidth>
         <Source dark code={exampleSetup} />
-        <FabCard onClick={() => setOpen(true)} layoutId="custom-modal" icon="mdi:cog" />
+        <FabCard onClick={() => setOpen(true)} icon="mdi:cog" />
         <Modal
-          id="custom-modal"
           open={open}
           title="Settings"
           onClose={() => {
@@ -102,14 +100,12 @@ const exampleRenderByDomain = `
   import { useId } from 'react';
   function CustomButton() {
     const [open, setOpen] = useState(false);
-    const _id = useId();
     return (
       <>
         <-- The trigger element can be any motion element, 
         in this case we use a FabCard which is a motion.button element -->
-        <FabCard layoutId={_id} onClick={() => setOpen(true)} icon="mdi:cog" />
+        <FabCard onClick={() => setOpen(true)} icon="mdi:cog" />
         <ModalByEntityDomain
-          id={_id}
           entity="light.fake_light_1"
           open={open}
           title="Settings"
@@ -141,11 +137,10 @@ function TestingModalStore() {
   const [open, setOpen] = useState(false);
   return (
     <>
-      <FabCard onClick={() => setOpen(true)} layoutId="custom-modal" icon="mdi:cog" cssStyles={`width: 250px`}>
+      <FabCard onClick={() => setOpen(true)} icon="mdi:cog" cssStyles={`width: 250px`}>
         CLICK ME
       </FabCard>
       <Modal
-        id="custom-modal"
         open={open}
         title="Settings"
         onClose={() => {
@@ -218,6 +213,43 @@ function RenderModalProvider() {
           <Source dark code={example} />
         </Column>
       </ModalProvider>
+    </HassConnect>
+  );
+}
+
+
+function Inner() {
+  const [open, setOpen] = useState(false);
+  const _id = useId();
+  return (
+    <>
+      <FabCard layoutId={_id} onClick={() => setOpen(true)} icon="mdi:cog" cssStyles={`width: 250px`}>
+        CLICK ME
+      </FabCard>
+      <Modal
+        id={_id}
+        open={open}
+        title="Settings"
+        onClose={() => {
+          setOpen(false);
+        }}
+      >
+        Add your settings here!
+      </Modal>
+    </>
+  );
+}
+
+function RenderAutoScaleFromSource() {
+  return (
+    <HassConnect hassUrl="http://localhost:8123">
+      <ThemeProvider includeThemeControls />
+      <Column gap="1rem" fullWidth>
+        <Inner />
+        <p>As shown before, from the trigger motion element or any card, if you add `layoutId` with a uniq id name, and then provide the `id` attribute to the modal of the same value, the modal will open as if it was expanding from the originating source, and will collapse when closing back to the original element too.</p>
+        <p><b>Note: </b>This has a side effect of initial layout animations where the card will animate to a default position initially</p>
+        <Source dark code={jsxToString(Inner())} />
+      </Column>
     </HassConnect>
   );
 }
@@ -381,10 +413,6 @@ function RenderModalAnimationExample() {
             have a preset of animate, exit and initial animation properties available and supports all properties that framer motion allows
             you to animate.
           </P>
-          <P>
-            You can also simply provide a `layoutId` which is what&apos;s used by default within the modal component to create the default
-            animation.
-          </P>
           <P>You can animate the modal, content and header separately!</P>
           <P>
             Here&apos;s some example references for animations with{" "}
@@ -451,5 +479,10 @@ export const ReplaceModalAnimation: ModalStory = {
 
 export const DisableComplexAnimations: ModalStory = {
   render: RenderModalProviderDisableAnimation,
+  args: {},
+};
+
+export const AutoScaleFromSource: ModalStory = {
+  render: RenderAutoScaleFromSource,
   args: {},
 };

--- a/packages/components/src/Shared/Modal/index.tsx
+++ b/packages/components/src/Shared/Modal/index.tsx
@@ -157,7 +157,7 @@ const LAYOUT_MODAL_ANIMATION: CustomModalAnimation = (duration, id) => {
     modal: {
       layoutId: id,
       variants: {
-        initial: { y: "100%", opacity: 0, scaleY: 0, }, // Slide up from the bottom
+        initial: { y: "100%", opacity: 0, scaleY: 0 }, // Slide up from the bottom
         animate: {
           y: 0,
           opacity: 1,
@@ -179,14 +179,12 @@ const LAYOUT_MODAL_ANIMATION: CustomModalAnimation = (duration, id) => {
           y: 0,
           opacity: 1,
           scale: 1,
-          transition: fadeSlideTransition
+          transition: fadeSlideTransition,
         },
         exit: { y: "10%", opacity: 0, scale: 0.9, transition: fadeSlideTransition },
       },
     },
-    content: {
-      
-    },
+    content: {},
   };
 };
 
@@ -352,12 +350,10 @@ function InternalModal({
                 {...content}
                 className={"modal-inner"}
                 style={{
-                  transformOrigin: 'top'
+                  transformOrigin: "top",
                 }}
               >
-                <AnimatePresence>
-                  {(ready || hasCustomAnimation) && children}
-                </AnimatePresence>
+                <AnimatePresence>{(ready || hasCustomAnimation) && children}</AnimatePresence>
               </ModalInner>
             </ModalOverflow>
           </ModalContainer>

--- a/packages/components/src/Shared/Modal/index.tsx
+++ b/packages/components/src/Shared/Modal/index.tsx
@@ -3,7 +3,7 @@ import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { localize, useHass } from "@hakit/core";
 import { AnimatePresence, HTMLMotionProps, MotionProps, type Variant, type Transition, motion } from "framer-motion";
-import { Fragment, ReactNode, memo, useCallback, useEffect, useRef, useState } from "react";
+import { Fragment, ReactNode, memo, useCallback, useEffect, useId, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { ErrorBoundary } from "react-error-boundary";
 import { useKeyPress } from "react-use";
@@ -120,8 +120,6 @@ type Extendable = React.ComponentPropsWithoutRef<"div"> & MotionProps;
 export interface ModalProps extends Omit<Extendable, "title"> {
   /** triggers the modal opening */
   open: boolean;
-  /** the id to provide for framer-motion, this should link back to another layoutId property on the element triggering the Modal */
-  id: string;
   /** the react layout to include inside the Modal */
   children: React.ReactNode;
   /** The title of the dialog */
@@ -142,52 +140,52 @@ export interface ModalProps extends Omit<Extendable, "title"> {
   autocloseSeconds?: number;
 }
 const LAYOUT_MODAL_ANIMATION: CustomModalAnimation = (duration, id) => {
-  const transition = {
+  const springTransition = {
+    type: "spring",
+    damping: 10,
+    mass: 0.75,
+    stiffness: 100,
+    duration,
+  };
+
+  const fadeSlideTransition = {
     duration,
     ease: [0.42, 0, 0.58, 1],
   };
+
   return {
     modal: {
-      transition: {
-        duration,
-        type: "spring",
-        damping: 7.5,
-        mass: 0.55,
-        stiffness: 100,
-        layout: {
-          duration,
+      layoutId: id,
+      variants: {
+        initial: { y: "100%", opacity: 0, scaleY: 0, }, // Slide up from the bottom
+        animate: {
+          y: 0,
+          opacity: 1,
+          scaleY: 1,
+          transition: springTransition,
+        },
+        exit: {
+          y: "100%",
+          scaleY: 0,
+          opacity: 0,
+          transition: fadeSlideTransition,
         },
       },
-      layoutId: id,
     },
     header: {
       variants: {
-        exit: { y: "-10%", opacity: 0, transition, scale: 0.9 },
-        initial: { y: "-10%", opacity: 0, transition, scale: 0.9 },
+        initial: { y: "-10%", opacity: 0, scale: 0 },
         animate: {
-          scale: 1,
           y: 0,
-          x: 0,
           opacity: 1,
-          transition: {
-            ...transition,
-            delay: duration / 2,
-          },
+          scale: 1,
+          transition: fadeSlideTransition
         },
+        exit: { y: "10%", opacity: 0, scale: 0.9, transition: fadeSlideTransition },
       },
     },
     content: {
-      variants: {
-        exit: { y: "-10%", opacity: 0, transition, scale: 0.9 },
-        initial: { y: "-10%", opacity: 0, transition, scale: 0.9 },
-        animate: {
-          scale: 1,
-          y: 0,
-          x: 0,
-          opacity: 1,
-          transition,
-        },
-      },
+      
     },
   };
 };
@@ -209,11 +207,12 @@ function InternalModal({
   autocloseSeconds = undefined,
   ...rest
 }: ModalProps) {
+  const _id = useId();
+  const prefix = id ?? _id;
   const { useStore } = useHass();
   const modalStore = useModalStore();
   const globalComponentStyle = useStore((state) => state.globalComponentStyles);
   const portalRoot = useStore((store) => store.portalRoot);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
   const [ready, setReady] = useState(false);
   const [isPressed] = useKeyPress((event) => event.key === "Escape");
   const duration = modalStore.animationDuration ?? animationDuration;
@@ -254,14 +253,10 @@ function InternalModal({
     // this will delay the rendering of the children until the animation
     // is complete
     if (!open) return;
-    if (timerRef.current) return;
-    timerRef.current = setTimeout(() => {
-      setReady(true);
-      timerRef.current = null;
-    }, duration);
-  }, [duration, open]);
+    setReady(true);
+  }, [open]);
 
-  const { modal = {}, content = {}, header = {} } = animation(duration, id);
+  const { modal = {}, content = {}, header = {} } = animation(duration, prefix);
 
   return createPortal(
     <AnimatePresence
@@ -272,11 +267,11 @@ function InternalModal({
       }}
     >
       {open && (
-        <Fragment key={`${id}-fragment`}>
+        <Fragment key={`${prefix}-fragment`}>
           <ModalBackdrop
-            key={`${id}-backdrop`}
+            key={`${prefix}-backdrop`}
             className="modal-backdrop"
-            id={`${id}-backdrop`}
+            id={`${prefix}-backdrop`}
             initial={{
               opacity: 0,
             }}
@@ -310,11 +305,11 @@ function InternalModal({
             initial="initial"
             animate="animate"
             exit="exit"
-            onAnimationComplete={() => {
+            onAnimationStart={() => {
               delayUpdate();
             }}
             {...modal}
-            key={`${id}-container`}
+            key={`${prefix}-container`}
             className={`modal-container ${className ?? ""}`}
           >
             <ModalHeader className={`modal-header`} initial="initial" animate="animate" exit="exit" {...header}>
@@ -352,13 +347,15 @@ function InternalModal({
             </ModalHeader>
             <ModalOverflow className={`modal-overflow`}>
               <ModalInner
-                initial="initial"
                 animate={ready || hasCustomAnimation ? "animate" : "initial"}
                 exit="exit"
                 {...content}
                 className={"modal-inner"}
+                style={{
+                  transformOrigin: 'top'
+                }}
               >
-                <AnimatePresence initial={false} mode="wait">
+                <AnimatePresence>
                   {(ready || hasCustomAnimation) && children}
                 </AnimatePresence>
               </ModalInner>

--- a/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
+++ b/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
@@ -9,6 +9,7 @@ import type { ThemeProviderProps } from "@components";
 import jsxToString from "react-element-to-jsx-string";
 import { ThemeControlsProps } from "./ThemeControls";
 import { DEFAULT_THEME_OPTIONS } from "./constants";
+import { redirectToStory } from '../../../../.storybook/redirect';
 
 const customTheme: ThemeProviderProps<{
   anything: {
@@ -141,7 +142,10 @@ function Render(args: Story["args"]) {
       <h3>Breakpoints</h3>
       <p>
         You can also customize the breakpoints used for your dashboard if you wish and the defaults aren&quot;t working for you, see more{" "}
-        <a href="/?path=/docs/introduction-responsive-layouts-breakpoints--docs">here</a>.
+        <a href="#" onClick={(e) => {
+          e.preventDefault();
+          redirectToStory('/docs/introduction-responsive-layouts-breakpoints--docs');
+        }}>here</a>.
       </p>
     </HassConnect>
   );

--- a/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
+++ b/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
@@ -9,7 +9,7 @@ import type { ThemeProviderProps } from "@components";
 import jsxToString from "react-element-to-jsx-string";
 import { ThemeControlsProps } from "./ThemeControls";
 import { DEFAULT_THEME_OPTIONS } from "./constants";
-import { redirectToStory } from '../../../../.storybook/redirect';
+import { redirectToStory } from "../../../../.storybook/redirect";
 
 const customTheme: ThemeProviderProps<{
   anything: {
@@ -142,10 +142,16 @@ function Render(args: Story["args"]) {
       <h3>Breakpoints</h3>
       <p>
         You can also customize the breakpoints used for your dashboard if you wish and the defaults aren&quot;t working for you, see more{" "}
-        <a href="#" onClick={(e) => {
-          e.preventDefault();
-          redirectToStory('/docs/introduction-responsive-layouts-breakpoints--docs');
-        }}>here</a>.
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            redirectToStory("/docs/introduction-responsive-layouts-breakpoints--docs");
+          }}
+        >
+          here
+        </a>
+        .
       </p>
     </HassConnect>
   );

--- a/packages/components/src/ThemeProvider/index.tsx
+++ b/packages/components/src/ThemeProvider/index.tsx
@@ -409,7 +409,6 @@ const InternalThemeProvider = memo(function InternalThemeProvider<T extends obje
             onClick={() => setOpen(true)}
             tooltipPlacement="left"
             title={localize("theme")}
-            layoutId="theme-controls"
             icon="mdi:color"
           />
         </ThemeControlsBox>
@@ -417,7 +416,6 @@ const InternalThemeProvider = memo(function InternalThemeProvider<T extends obje
       {includeThemeControls && (
         <Modal
           description="This interface showcases how the colors will behave and provides easy to access css variables"
-          id="theme-controls"
           open={open}
           title={localize("theme")}
           onClose={() => {

--- a/packages/components/src/ThemeProvider/index.tsx
+++ b/packages/components/src/ThemeProvider/index.tsx
@@ -405,12 +405,7 @@ const InternalThemeProvider = memo(function InternalThemeProvider<T extends obje
             ...(themeControlStyles ?? {}),
           }}
         >
-          <FabCard
-            onClick={() => setOpen(true)}
-            tooltipPlacement="left"
-            title={localize("theme")}
-            icon="mdi:color"
-          />
+          <FabCard onClick={() => setOpen(true)} tooltipPlacement="left" title={localize("theme")} icon="mdi:color" />
         </ThemeControlsBox>
       )}
       {includeThemeControls && (

--- a/packages/components/vite-env.d.ts
+++ b/packages/components/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/core/src/HassConnect/Provider.tsx
+++ b/packages/core/src/HassConnect/Provider.tsx
@@ -375,7 +375,7 @@ export function HassProvider({ children, hassUrl, hassToken, locale, portalRoot 
       console.log("Error:", e);
       return {
         status: "error",
-        data: `API Request failed for endpoint "${endpoint}", follow instructions here: https://shannonhochkins.github.io/ha-component-kit/?path=/docs/hooks-usehass-callapi--docs.`,
+        data: `API Request failed for endpoint "${endpoint}", follow instructions here: https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-usehass-hass-callapi--docs.`,
       };
     }
   }

--- a/packages/core/src/HassConnect/index.tsx
+++ b/packages/core/src/HassConnect/index.tsx
@@ -2,7 +2,6 @@ import { memo, useMemo, type ReactNode } from "react";
 import { useRef } from "react";
 import { HassProvider } from "./Provider";
 import type { HassProviderProps } from "./Provider";
-import { motion, AnimatePresence } from "framer-motion";
 import styled from "@emotion/styled";
 import { keyframes } from "@emotion/react";
 
@@ -19,12 +18,6 @@ export type HassConnectProps = {
   onReady?: () => void;
   /** options for the provider */
   options?: Omit<HassProviderProps, "children" | "hassUrl">;
-};
-
-const fadeIn = {
-  hidden: { opacity: 0 },
-  visible: { opacity: 1 },
-  exit: { opacity: 0 },
 };
 
 const blip = keyframes`
@@ -77,7 +70,7 @@ const Loader = styled(LoaderBase)`
   }
 `;
 
-const MotionDiv = styled(motion.div)`
+const Wrapper = styled.div`
   width: 100%;
   height: 100%;
 `;
@@ -111,9 +104,9 @@ export const HassConnect = memo(function HassConnect({
   return (
     <HassProvider hassUrl={sanitizedUrl} hassToken={hassToken} {...options}>
       {(ready) => (
-        <AnimatePresence mode="wait">
+        <>
           {ready ? (
-            <MotionDiv key="children" initial="hidden" animate="visible" exit="exit" variants={fadeIn}>
+            <Wrapper>
               {onReady &&
                 !onReadyCalled.current &&
                 ((() => {
@@ -122,13 +115,11 @@ export const HassConnect = memo(function HassConnect({
                 })(),
                 null)}
               {children}
-            </MotionDiv>
+            </Wrapper>
           ) : (
-            <MotionDiv key="loading" initial="hidden" animate="visible" exit="exit" variants={fadeIn}>
-              {loading}
-            </MotionDiv>
+            <Wrapper>{loading}</Wrapper>
           )}
-        </AnimatePresence>
+        </>
       )}
     </HassProvider>
   );

--- a/packages/core/src/helpers.stories.tsx
+++ b/packages/core/src/helpers.stories.tsx
@@ -193,6 +193,16 @@ import {
   getRGBContrastRatio, // Get the contrast ratio of 2 rgb colors
 } from '@hakit/core';`,
   },
+  {
+    name: 'temperature2rgb',
+    description: 'Converts a temperature in Kelvin to an RGB color',
+    comment: '',
+    exampleUsage: `
+const rgb = temperature2rgb(3000);
+const div = document.createElement('div');
+div.style.background = \`rgb(\${rgb.join(',')})\`;    
+`,
+  }
 ];
 
 export default {

--- a/packages/core/src/helpers.stories.tsx
+++ b/packages/core/src/helpers.stories.tsx
@@ -194,15 +194,15 @@ import {
 } from '@hakit/core';`,
   },
   {
-    name: 'temperature2rgb',
-    description: 'Converts a temperature in Kelvin to an RGB color',
-    comment: '',
+    name: "temperature2rgb",
+    description: "Converts a temperature in Kelvin to an RGB color",
+    comment: "",
     exampleUsage: `
 const rgb = temperature2rgb(3000);
 const div = document.createElement('div');
 div.style.background = \`rgb(\${rgb.join(',')})\`;    
 `,
-  }
+  },
 ];
 
 export default {

--- a/packages/core/src/hooks/useEntity/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/basic.code.tsx
@@ -1,13 +1,15 @@
-import { HassConnect, useEntity } from '@hakit/core';
+import { HassConnect, useEntity } from "@hakit/core";
 
 function Office() {
-  const lightStrip = useEntity('light.office_striplight');
+  const lightStrip = useEntity("light.office_striplight");
   // can now access all properties relating to the light
   return lightStrip.state;
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Office />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Office />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useEntity/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/basic.code.tsx
@@ -7,7 +7,7 @@ function Office() {
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
     <Office />
   </HassConnect>
 }

--- a/packages/core/src/hooks/useEntity/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/basic.code.tsx
@@ -1,0 +1,13 @@
+import { HassConnect, useEntity } from '@hakit/core';
+
+function Office() {
+  const lightStrip = useEntity('light.office_striplight');
+  // can now access all properties relating to the light
+  return lightStrip.state;
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://localhost:1234">
+    <Office />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useEntity/examples/service.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/service.code.tsx
@@ -1,12 +1,14 @@
-import { HassConnect, useEntity } from '@hakit/core';
+import { HassConnect, useEntity } from "@hakit/core";
 
 function UseServiceExample() {
-  const entity = useEntity('light.some_light_entity');
-  return <button onClick={() => entity.service.toggle()} >TOGGLE LIGHT</button>
+  const entity = useEntity("light.some_light_entity");
+  return <button onClick={() => entity.service.toggle()}>TOGGLE LIGHT</button>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <UseServiceExample />
-  </HassConnect>
-} 
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <UseServiceExample />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useEntity/examples/service.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/service.code.tsx
@@ -1,0 +1,12 @@
+import { HassConnect, useEntity } from '@hakit/core';
+
+function UseServiceExample() {
+  const entity = useEntity('light.some_light_entity');
+  return <button onClick={() => entity.service.toggle()} >TOGGLE LIGHT</button>
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://localhost:1234">
+    <UseServiceExample />
+  </HassConnect>
+} 

--- a/packages/core/src/hooks/useEntity/examples/serviceResponse.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/serviceResponse.code.tsx
@@ -1,5 +1,5 @@
-import { HassConnect, useEntity } from '@hakit/core';
-import { useState, useCallback } from 'react';
+import { HassConnect, useEntity } from "@hakit/core";
+import { useState, useCallback } from "react";
 
 interface CalendarEvent {
   description: string;
@@ -10,34 +10,40 @@ interface CalendarEvent {
 interface CalendarResponse {
   "calendar.some_calendar": {
     events: CalendarEvent[];
-  }
+  };
 }
 function CallServiceExample() {
-  const entity = useEntity('calendar.some_calendar');
+  const entity = useEntity("calendar.some_calendar");
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   const getEvents = useCallback(() => {
-    entity.service.getEvents<CalendarResponse>({
-      returnResponse: true,
-      serviceData: {
-        start_date_time: '2024-12-22 20:00:00',
-        duration: {
-          days: 24
-        }
-      }
-    }).then(({ response, context }) => {
-      console.log('response', context, response);
-      const events = response['calendar.some_calendar']?.events || [];
-      setEvents(events);
-    });
+    entity.service
+      .getEvents<CalendarResponse>({
+        returnResponse: true,
+        serviceData: {
+          start_date_time: "2024-12-22 20:00:00",
+          duration: {
+            days: 24,
+          },
+        },
+      })
+      .then(({ response, context }) => {
+        console.log("response", context, response);
+        const events = response["calendar.some_calendar"]?.events || [];
+        setEvents(events);
+      });
   }, [entity]);
-  return <>
-    <p>Events: {events.length}</p>
-   <button onClick={getEvents}>GET EVENTS</button>
-  </>
+  return (
+    <>
+      <p>Events: {events.length}</p>
+      <button onClick={getEvents}>GET EVENTS</button>
+    </>
+  );
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <CallServiceExample />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <CallServiceExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useEntity/examples/serviceResponse.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/serviceResponse.code.tsx
@@ -1,0 +1,43 @@
+import { HassConnect, useEntity } from '@hakit/core';
+import { useState, useCallback } from 'react';
+
+interface CalendarEvent {
+  description: string;
+  end: string;
+  start: string;
+  summary: string;
+}
+interface CalendarResponse {
+  "calendar.some_calendar": {
+    events: CalendarEvent[];
+  }
+}
+function CallServiceExample() {
+  const entity = useEntity('calendar.some_calendar');
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const getEvents = useCallback(() => {
+    entity.service.getEvents<CalendarResponse>({
+      returnResponse: true,
+      serviceData: {
+        start_date_time: '2024-12-22 20:00:00',
+        duration: {
+          days: 24
+        }
+      }
+    }).then(({ response, context }) => {
+      console.log('response', context, response);
+      const events = response['calendar.some_calendar']?.events || [];
+      setEvents(events);
+    });
+  }, [entity]);
+  return <>
+    <p>Events: {events.length}</p>
+   <button onClick={getEvents}>GET EVENTS</button>
+  </>
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://localhost:1234">
+    <CallServiceExample />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useEntity/examples/serviceResponse.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/serviceResponse.code.tsx
@@ -37,7 +37,7 @@ function CallServiceExample() {
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
     <CallServiceExample />
   </HassConnect>
 }

--- a/packages/core/src/hooks/useEntity/examples/withHistory.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/withHistory.code.tsx
@@ -14,7 +14,7 @@ function Office() {
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
     <Office />
   </HassConnect>
 }

--- a/packages/core/src/hooks/useEntity/examples/withHistory.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/withHistory.code.tsx
@@ -1,20 +1,22 @@
-import { HassConnect, useEntity } from '@hakit/core';
+import { HassConnect, useEntity } from "@hakit/core";
 
 function Office() {
-  const lightStrip = useEntity('light.office_striplight', {
+  const lightStrip = useEntity("light.office_striplight", {
     returnNullIfNotFound: true,
     history: {
       disable: false,
-      hoursToShow: 96 // defaults to 24
-    }
+      hoursToShow: 96, // defaults to 24
+    },
   });
-  console.info('light history', lightStrip?.history);
+  console.info("light history", lightStrip?.history);
   // can now access all properties relating to the light
-  return lightStrip?.state ?? 'unknown';
+  return lightStrip?.state ?? "unknown";
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Office />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Office />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useEntity/examples/withHistory.code.tsx
+++ b/packages/core/src/hooks/useEntity/examples/withHistory.code.tsx
@@ -1,0 +1,20 @@
+import { HassConnect, useEntity } from '@hakit/core';
+
+function Office() {
+  const lightStrip = useEntity('light.office_striplight', {
+    returnNullIfNotFound: true,
+    history: {
+      disable: false,
+      hoursToShow: 96 // defaults to 24
+    }
+  });
+  console.info('light history', lightStrip?.history);
+  // can now access all properties relating to the light
+  return lightStrip?.state ?? 'unknown';
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://localhost:1234">
+    <Office />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useEntity/useEntity.mdx
+++ b/packages/core/src/hooks/useEntity/useEntity.mdx
@@ -1,14 +1,16 @@
 import { Source, Meta } from '@storybook/blocks';
 
+import basicExample from './examples/basic.code?raw';
+import serviceExample from './examples/service.code?raw';
+import serviceResponseExample from './examples/serviceResponse.code?raw';
+import historyExample from './examples/withHistory.code?raw';
+
 <Meta title="core/hooks/useEntity" />
 # useEntity()
 ###### `useEntity(entity: string, options?: UseEntityOptions)`
 This hook is designed to retrieve an entity and return all it's information including history (if not disabled) and the services for the entity.
 
-This is a memoized wrapper for the getEntity helper from `useHass()` allowing your component to only update
-when the entity actually changes.
-
-This hook should be used inside the context of `<HassConnect />` and not outside of it otherwise it will not have access to
+This hook should be used inside the context of [`<HassConnect />`](/docs/core-hassconnect--docs) and not outside of it otherwise it will not have access to
 the authenticated home assistant API.
 
 <iframe
@@ -16,32 +18,19 @@ the authenticated home assistant API.
     margin: "auto",
     display: "block",
     marginTop: "20px",
+    border: 0,
   }}
   width="560"
   height="315"
-  frameBorder={0}
   src="https://www.youtube.com/embed/kmNGka8obNA"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
   allowFullScreen
 ></iframe>
 
 
-
 ### Example Usage
 
-<Source dark code={`
-import { HassConnect, useEntity } from '@hakit/core';
-function Office() {
-  const lightStrip = useEntity('light.office_striplight');
-  // can now access all properties relating to the light
-  return lightStrip.state;
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Office />
-  </HassConnect>
-}
-`} />
+<Source dark code={basicExample} />
 
 ### Options
 useEntity takes a second parameter which is an object of options.
@@ -52,76 +41,15 @@ The options are:
 
 Example:
 
-<Source dark code={`
-import { HassConnect, useEntity } from '@hakit/core';
-function Office() {
-  const lightStrip = useEntity('light.office_striplight', {
-    returnNullIfNotFound: true,
-    history: {
-      disable: false,
-      hoursToShow: 96 // defaults to 24
-    }
-  });
-  console.info('light history', lightStrip.history);
-  // can now access all properties relating to the light
-  return lightStrip?.state ?? 'unknown';
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Office />
-  </HassConnect>
-}
-`} />
+<Source dark code={historyExample} />
 
 ### Using services from entity
 The `useEntity()` hook is integrated with the `useService` hook so you can use it directly from the entity object.
 Everything is typed so it makes it very easy to use and develop with.
-<Source dark code={`
-import { HassConnect, useEntity } from '@hakit/core';
-function UseServiceExample() {
-  const entity = useEntity('light.some_light_entity');
-  return <button onClick={() => entity.service.toggle()} >TOGGLE LIGHT</button>
-}
-`} />
+<Source dark code={serviceExample} />
 
 
 ### Getting a response back from a service
 Some services return a response, like the calendar `getEvents` service, you can access this response value by adding `returnResponse` to the service call.
 The response object type is able to be defined by passing a generic type to the service call itself, see example below:
-<Source dark code={`
-import { useEntity } from '@hakit/core';
-import { useState, useCallback } from 'react';
-interface CalendarEvent {
-  description: string;
-  end: string;
-  start: string;
-  summary: string;
-}
-interface CalendarResponse {
-  "calendar.some_calendar": {
-    events: CalendarEvent[];
-  }
-}
-function CallServiceExample() {
-  const entity = useEntity('calendar.some_calendar');
-  const [events, setEvents] = useState<CalendarEvent[]>([]);
-  const getEvents = useCallback(() => {
-    entity.service.getEvents<CalendarResponse>({
-      returnResponse: true,
-      target: 'calendar.some_calendar',
-      serviceData: {
-        start_date_time: '2024-12-22 20:00:00',
-        duration: {
-          days: 24
-        }
-      }
-    }).then((response) => {
-      setEvents(response.events);
-    });
-  }, [entity]);
-  return <>
-    <p>Events: {events.length}</p>
-   <button onClick={getEvents}>GET EVENTS</button>
-  </>
-}
-`} />
+<Source dark code={serviceResponseExample} />

--- a/packages/core/src/hooks/useHass/examples/callApi.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/callApi.code.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useState } from 'react';
-import { useHass, HassConnect } from '@hakit/core';
+import { useEffect, useState } from "react";
+import { useHass, HassConnect } from "@hakit/core";
 export type DateFormat = {
   dateTime: string;
   date: string;
@@ -19,21 +19,27 @@ export function CallApiExample() {
   const { callApi } = useHass();
   const [events, setEvents] = useState<CalendarEvent[]>([]);
   useEffect(() => {
-    callApi<CalendarEvent[]>('/calendars/calendar.google_calendar?start=2023-09-30T14:00:00.000Z&end=2023-11-11T13:00:00.000Z').then(response => {
-      if (response.status === 'success') {
-        setEvents(response.data);
-      } else {
-        console.error('Error', response.data);
-      }
-    });
+    callApi<CalendarEvent[]>("/calendars/calendar.google_calendar?start=2023-09-30T14:00:00.000Z&end=2023-11-11T13:00:00.000Z").then(
+      (response) => {
+        if (response.status === "success") {
+          setEvents(response.data);
+        } else {
+          console.error("Error", response.data);
+        }
+      },
+    );
   }, [callApi]);
-  return <>
-    <p>{events.length ? `There is ${events.length} events!` : 'No events'}</p>
-  </>
+  return (
+    <>
+      <p>{events.length ? `There is ${events.length} events!` : "No events"}</p>
+    </>
+  );
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <CallApiExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <CallApiExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/callApi.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/callApi.code.tsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import { useHass, HassConnect } from '@hakit/core';
+export type DateFormat = {
+  dateTime: string;
+  date: string;
+};
+
+export interface CalendarEvent {
+  start: DateFormat;
+  end: DateFormat;
+  summary: string;
+  location?: string;
+  description?: string;
+  uid?: string;
+  recurrence_id?: string;
+  rrule?: string;
+}
+export function CallApiExample() {
+  const { callApi } = useHass();
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  useEffect(() => {
+    callApi<CalendarEvent[]>('/calendars/calendar.google_calendar?start=2023-09-30T14:00:00.000Z&end=2023-11-11T13:00:00.000Z').then(response => {
+      if (response.status === 'success') {
+        setEvents(response.data);
+      } else {
+        console.error('Error', response.data);
+      }
+    });
+  }, [callApi]);
+  return <>
+    <p>{events.length ? `There is ${events.length} events!` : 'No events'}</p>
+  </>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <CallApiExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/getAllEntities.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getAllEntities.code.tsx
@@ -1,0 +1,14 @@
+import { useHass } from '@hakit/core';
+import { HassConnect } from '@hakit/core';
+
+export function GetEntitiesExample() {
+  const { getAllEntities } = useHass();
+  const entities = getAllEntities();
+  return <p>You have {Object.keys(entities).length} entities</p>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <GetEntitiesExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/getAllEntities.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getAllEntities.code.tsx
@@ -1,14 +1,16 @@
-import { useHass } from '@hakit/core';
-import { HassConnect } from '@hakit/core';
+import { useHass } from "@hakit/core";
+import { HassConnect } from "@hakit/core";
 
 export function GetEntitiesExample() {
   const { getAllEntities } = useHass();
   const entities = getAllEntities();
-  return <p>You have {Object.keys(entities).length} entities</p>
+  return <p>You have {Object.keys(entities).length} entities</p>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <GetEntitiesExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <GetEntitiesExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/getConfig.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getConfig.code.tsx
@@ -1,25 +1,26 @@
-
-import { useEffect, useState } from 'react';
-import { useHass, HassConnect } from '@hakit/core';
-import { type HassConfig } from 'home-assistant-js-websocket';
+import { useEffect, useState } from "react";
+import { useHass, HassConnect } from "@hakit/core";
+import { type HassConfig } from "home-assistant-js-websocket";
 
 export function GetConfigExample() {
   const { getConfig } = useHass();
   const [config, setConfig] = useState<HassConfig | null>(null);
 
   useEffect(() => {
-    getConfig().then(config => {
+    getConfig().then((config) => {
       if (config) {
         setConfig(config);
       }
     });
   }, [getConfig]);
-  
-  return <p>Your home assistant instance is {config?.state}</p>
+
+  return <p>Your home assistant instance is {config?.state}</p>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <GetConfigExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <GetConfigExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/getConfig.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getConfig.code.tsx
@@ -1,0 +1,25 @@
+
+import { useEffect, useState } from 'react';
+import { useHass, HassConnect } from '@hakit/core';
+import { type HassConfig } from 'home-assistant-js-websocket';
+
+export function GetConfigExample() {
+  const { getConfig } = useHass();
+  const [config, setConfig] = useState<HassConfig | null>(null);
+
+  useEffect(() => {
+    getConfig().then(config => {
+      if (config) {
+        setConfig(config);
+      }
+    });
+  }, [getConfig]);
+  
+  return <p>Your home assistant instance is {config?.state}</p>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <GetConfigExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/getServices.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getServices.code.tsx
@@ -1,21 +1,22 @@
-import { type HassServices } from 'home-assistant-js-websocket';
-import { useHass, HassConnect } from '@hakit/core';
-import { useEffect, useState } from 'react';
+import { type HassServices } from "home-assistant-js-websocket";
+import { useHass, HassConnect } from "@hakit/core";
+import { useEffect, useState } from "react";
 
 export function GetServicesExample() {
   const { getServices } = useHass();
   const [services, setServices] = useState<HassServices | null>(null);
-  
+
   useEffect(() => {
-    getServices().then(services => setServices(services));
+    getServices().then((services) => setServices(services));
   }, [getServices]);
   // print the result when ready
   return <pre>{JSON.stringify(services, null, 2)}</pre>;
 }
 
-
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <GetServicesExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <GetServicesExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/getServices.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getServices.code.tsx
@@ -1,0 +1,21 @@
+import { type HassServices } from 'home-assistant-js-websocket';
+import { useHass, HassConnect } from '@hakit/core';
+import { useEffect, useState } from 'react';
+
+export function GetServicesExample() {
+  const { getServices } = useHass();
+  const [services, setServices] = useState<HassServices | null>(null);
+  
+  useEffect(() => {
+    getServices().then(services => setServices(services));
+  }, [getServices]);
+  // print the result when ready
+  return <pre>{JSON.stringify(services, null, 2)}</pre>;
+}
+
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <GetServicesExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/getStates.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getStates.code.tsx
@@ -1,18 +1,20 @@
-import { type HassEntity } from 'home-assistant-js-websocket';
-import { useHass, HassConnect } from '@hakit/core';
-import { useEffect, useState } from 'react';
+import { type HassEntity } from "home-assistant-js-websocket";
+import { useHass, HassConnect } from "@hakit/core";
+import { useEffect, useState } from "react";
 
 export function GetStatesExample() {
   const { getStates } = useHass();
   const [states, setStates] = useState<HassEntity[] | null>(null);
   useEffect(() => {
-    getStates().then(states => setStates(states));
+    getStates().then((states) => setStates(states));
   }, [getStates]);
-  return <p>{JSON.stringify(states, null, 2)}</p>
+  return <p>{JSON.stringify(states, null, 2)}</p>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <GetStatesExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <GetStatesExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/getStates.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getStates.code.tsx
@@ -1,0 +1,18 @@
+import { type HassEntity } from 'home-assistant-js-websocket';
+import { useHass, HassConnect } from '@hakit/core';
+import { useEffect, useState } from 'react';
+
+export function GetStatesExample() {
+  const { getStates } = useHass();
+  const [states, setStates] = useState<HassEntity[] | null>(null);
+  useEffect(() => {
+    getStates().then(states => setStates(states));
+  }, [getStates]);
+  return <p>{JSON.stringify(states, null, 2)}</p>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <GetStatesExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/getUser.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getUser.code.tsx
@@ -1,20 +1,22 @@
-import { type HassUser } from 'home-assistant-js-websocket';
-import { useHass, HassConnect } from '@hakit/core';
-import { useEffect, useState } from 'react';
+import { type HassUser } from "home-assistant-js-websocket";
+import { useHass, HassConnect } from "@hakit/core";
+import { useEffect, useState } from "react";
 
 function GetUserExample() {
   const { getUser } = useHass();
   const [user, setUser] = useState<HassUser | null>(null);
-  
+
   useEffect(() => {
-    getUser().then(user => setUser(user));
+    getUser().then((user) => setUser(user));
   }, [getUser]);
 
-  return <p>{JSON.stringify(user, null, 2)}</p>
+  return <p>{JSON.stringify(user, null, 2)}</p>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <GetUserExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <GetUserExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/getUser.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/getUser.code.tsx
@@ -1,0 +1,20 @@
+import { type HassUser } from 'home-assistant-js-websocket';
+import { useHass, HassConnect } from '@hakit/core';
+import { useEffect, useState } from 'react';
+
+function GetUserExample() {
+  const { getUser } = useHass();
+  const [user, setUser] = useState<HassUser | null>(null);
+  
+  useEffect(() => {
+    getUser().then(user => setUser(user));
+  }, [getUser]);
+
+  return <p>{JSON.stringify(user, null, 2)}</p>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <GetUserExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/joinHassUrl.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/joinHassUrl.code.tsx
@@ -1,0 +1,14 @@
+
+import { useHass, HassConnect } from '@hakit/core';
+
+export function SomeComponent() {
+  const { joinHassUrl } = useHass();
+  const url = joinHassUrl('/something');
+  return <p>{url}</p>; // expected output: 'https://homeassistant.local:8123/something'
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <SomeComponent />
+  </HassConnect>;
+} 

--- a/packages/core/src/hooks/useHass/examples/joinHassUrl.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/joinHassUrl.code.tsx
@@ -1,14 +1,15 @@
-
-import { useHass, HassConnect } from '@hakit/core';
+import { useHass, HassConnect } from "@hakit/core";
 
 export function SomeComponent() {
   const { joinHassUrl } = useHass();
-  const url = joinHassUrl('/something');
+  const url = joinHassUrl("/something");
   return <p>{url}</p>; // expected output: 'https://homeassistant.local:8123/something'
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <SomeComponent />
-  </HassConnect>;
-} 
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <SomeComponent />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useHass/examples/useHass.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/useHass.code.tsx
@@ -1,0 +1,38 @@
+import { useHass, HassConnect } from '@hakit/core';
+
+function UseHassExample() {
+  const hass = useHass();
+  const { 
+    useStore,
+    logout,
+    getStates,
+    getServices,
+    getConfig,
+    getUser,
+    callService,
+    getAllEntities,
+    joinHassUrl,
+    callApi,
+   } = hass;
+  const entities = getAllEntities();
+  const light = entities['light.something'];
+  console.log(callService, 'is the internal function used by the `useService` hook.')
+  console.log(callApi, 'is the provided function to trigger api requests programmatically to your instance.')
+  console.log(getStates, 'Retrieve all information about the current state of your entities.');
+  console.log(getServices, 'Retrieve all available services on your instance.');
+  console.log(getUser, 'Retrieve the current user.');
+  console.log(getConfig, 'Retrieve the current configuration.');
+  console.log(logout, 'Logout the current authenticated instance');
+  console.log(joinHassUrl, 'Join a provided url with the current authenticated hass instance url.');
+  console.log('entities', entities);
+  console.log('light', light);
+  console.log(useStore, 'All information stored in the store is available.');
+  // can now access all properties relating to the light
+  return light.state;
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <UseHassExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/examples/useHass.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/useHass.code.tsx
@@ -1,38 +1,29 @@
-import { useHass, HassConnect } from '@hakit/core';
+import { useHass, HassConnect } from "@hakit/core";
 
 function UseHassExample() {
   const hass = useHass();
-  const { 
-    useStore,
-    logout,
-    getStates,
-    getServices,
-    getConfig,
-    getUser,
-    callService,
-    getAllEntities,
-    joinHassUrl,
-    callApi,
-   } = hass;
+  const { useStore, logout, getStates, getServices, getConfig, getUser, callService, getAllEntities, joinHassUrl, callApi } = hass;
   const entities = getAllEntities();
-  const light = entities['light.something'];
-  console.log(callService, 'is the internal function used by the `useService` hook.')
-  console.log(callApi, 'is the provided function to trigger api requests programmatically to your instance.')
-  console.log(getStates, 'Retrieve all information about the current state of your entities.');
-  console.log(getServices, 'Retrieve all available services on your instance.');
-  console.log(getUser, 'Retrieve the current user.');
-  console.log(getConfig, 'Retrieve the current configuration.');
-  console.log(logout, 'Logout the current authenticated instance');
-  console.log(joinHassUrl, 'Join a provided url with the current authenticated hass instance url.');
-  console.log('entities', entities);
-  console.log('light', light);
-  console.log(useStore, 'All information stored in the store is available.');
+  const light = entities["light.something"];
+  console.log(callService, "is the internal function used by the `useService` hook.");
+  console.log(callApi, "is the provided function to trigger api requests programmatically to your instance.");
+  console.log(getStates, "Retrieve all information about the current state of your entities.");
+  console.log(getServices, "Retrieve all available services on your instance.");
+  console.log(getUser, "Retrieve the current user.");
+  console.log(getConfig, "Retrieve the current configuration.");
+  console.log(logout, "Logout the current authenticated instance");
+  console.log(joinHassUrl, "Join a provided url with the current authenticated hass instance url.");
+  console.log("entities", entities);
+  console.log("light", light);
+  console.log(useStore, "All information stored in the store is available.");
   // can now access all properties relating to the light
   return light.state;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <UseHassExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <UseHassExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/useStore.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/useStore.code.tsx
@@ -1,24 +1,25 @@
-
-import { useHass, HassConnect } from '@hakit/core';
+import { useHass, HassConnect } from "@hakit/core";
 
 function UseStoreExample() {
   const { useStore } = useHass();
   // there's more available on the store than displayed here, this is just an example
-  const entities = useStore(store => store.entities);
-  const connection = useStore(store => store.connection);
-  const config = useStore(store => store.config);
-  const auth = useStore(store => store.auth);
-  console.log('data', {
+  const entities = useStore((store) => store.entities);
+  const connection = useStore((store) => store.connection);
+  const config = useStore((store) => store.config);
+  const auth = useStore((store) => store.auth);
+  console.log("data", {
     entities,
     connection,
     config,
-    auth
+    auth,
   });
-  return <p>{JSON.stringify(entities, null, 2)}</p>
+  return <p>{JSON.stringify(entities, null, 2)}</p>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <UseStoreExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <UseStoreExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHass/examples/useStore.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/useStore.code.tsx
@@ -1,0 +1,24 @@
+
+import { useHass, HassConnect } from '@hakit/core';
+
+function UseStoreExample() {
+  const { useStore } = useHass();
+  // there's more available on the store than displayed here, this is just an example
+  const entities = useStore(store => store.entities);
+  const connection = useStore(store => store.connection);
+  const config = useStore(store => store.config);
+  const auth = useStore(store => store.auth);
+  console.log('data', {
+    entities,
+    connection,
+    config,
+    auth
+  });
+  return <p>{JSON.stringify(entities, null, 2)}</p>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <UseStoreExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useHass/useHass.callApi.mdx
+++ b/packages/core/src/hooks/useHass/useHass.callApi.mdx
@@ -1,63 +1,33 @@
 import { Source, Meta } from '@storybook/blocks';
+import callApiExample from './examples/callApi.code?raw';
 
-<Meta title="core/hooks/useHass/callApi" />
+<Meta title="core/hooks/useHass/hass/callApi" />
 
 # callApi()
 ###### `callApi(endpoint: string, options?: FetchOptions)`
 This will trigger a request to the [REST API](https://developers.home-assistant.io/docs/api/rest/#actions) for home assistant.
 
+The [api integration](https://www.home-assistant.io/integrations/api/) exposes a RESTful API and allows one to interact with a Home Assistant instance that is running headless. This integration depends on the [HTTP integration](https://www.home-assistant.io/integrations/http/).
+
 By default, this will trigger a GET request, you'll need to provide the options argument to update the method and body of the request of changing to POST.
 
-You will at least need to add the following to your configuration.yaml in home assistant to [enable the api](https://www.home-assistant.io/integrations/api):
+> **1**: If you are not using the [frontend](https://www.home-assistant.io/integrations/frontend/) in your setup then you need to add the [api integration](https://www.home-assistant.io/integrations/api/) to your configuration.yaml file.
 
-<Source dark language="yaml" code={`
-# Example configuration.yaml entry
-api:
-`} />
+> **2**: You do not need to provide the `/api` prefix to the endpoint. This is added automatically.
 
-**NOTE**: If you're developing locally, you'll need to add the port of your local server to the `cors_allowed_origins` list in your configuration.yaml, example:
+> **3**: If you're developing locally, you may need to add the port of your local server to the `cors_allowed_origins` list in your configuration.yaml for the [http integration](https://www.home-assistant.io/integrations/http/), example:
 
 <Source dark language="yaml" code={`
 # Example configuration.yaml entry
 http:
   cors_allowed_origins: 
-    - http://localhost:8080
+    # local development service
+    - http://localhost:1234
 `} />
 
 ### Example Usage
 The below is an example of how to use the hook to retrieve calendar events from home assistant.
-I recomend you read the documentation for the [REST API](https://developers.home-assistant.io/docs/api/rest/#actions) before attempting to use the callApi function as it will help you understand what you need to pass to the function and what you can expect to get back.
+I recommend you read the documentation for the [REST API](https://developers.home-assistant.io/docs/api/rest/#actions) before attempting to use the callApi function as it will help you understand what you need to pass to the function and what you can expect to get back.
 
-<Source dark language="ts" code={`
-import { useCallback, useState } from 'react';
-import { useHass } from '@hakit/core';
-export type DateFormat = {
-  dateTime: string;
-  date: string;
-};
+<Source dark language="ts" code={callApiExample} />
 
-export interface CalendarEvent {
-  start: DateFormat;
-  end: DateFormat;
-  summary: string;
-  location?: string;
-  description?: string;
-  uid?: string;
-  recurrence_id?: string;
-  rrule?: string;
-}
-export function CallApiExample() {
-  const { callApi } = useHass();
-  const [events, setEvents] = useState<CalendarEvent[]>([]);
-  const retrieveCalendarEvents = useCallback(() => {
-    const response = await callApi<CalendarEvent[]>('/calendars/calendar.google_calendar?start=2023-09-30T14:00:00.000Z&end=2023-11-11T13:00:00.000Z');
-    setEvents(response);
-  }, [callApi]);
-  return <>
-    <FabCard icon="mdi:view-module" onClick={retrieveCalendarEvents} />
-    {events.length ? \`There is $\{events.length} events!\` : 'No events'}
-  </>
-}
-`} />
-
-**NOTE**: You do not need to provide the /api prefix to the endpoint. This is added automatically.

--- a/packages/core/src/hooks/useHass/useHass.callService.mdx
+++ b/packages/core/src/hooks/useHass/useHass.callService.mdx
@@ -1,6 +1,6 @@
 import { Source, Meta } from '@storybook/blocks';
 
-<Meta title="core/hooks/useHass/callService" />
+<Meta title="core/hooks/useHass/hass/callService" />
 
 # callService()
 ###### `callService(args: CallServiceArgs<ResponseType, SnakeOrCamelDomain, DomainService<SnakeOrCamelDomain>>)`

--- a/packages/core/src/hooks/useHass/useHass.getAllEntities.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getAllEntities.mdx
@@ -1,6 +1,7 @@
 import { Source, Meta } from '@storybook/blocks';
+import getAllEntitiesExample from './examples/getAllEntities.code?raw';
 
-<Meta title="core/hooks/useHass/getAllEntities" />
+<Meta title="core/hooks/useHass/hass/getAllEntities" />
 
 # getAllEntities()
 
@@ -12,9 +13,4 @@ This will return every entity available in your home assistant instance as an ob
 
 ### Example Usage
 
-```ts
-function GetEntitiesExample() {
-  const { getAllEntities } = useHass();
-  const entities = getAllEntities();
-  return <p>You have {Object.keys(entities).length} entities</p>
-}
+<Source dark language="ts" code={getAllEntitiesExample} />

--- a/packages/core/src/hooks/useHass/useHass.getConfig.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getConfig.mdx
@@ -1,7 +1,8 @@
 import { Source, Meta } from '@storybook/blocks';
+import getConfigExample from './examples/getConfig.code?raw';
 
 
-<Meta title="core/hooks/useHass/getConfig" />
+<Meta title="core/hooks/useHass/hass/getConfig" />
 
 # getConfig()
 This will return all information about your configuration of your home assistant instance, this is all typed with typescript
@@ -13,16 +14,4 @@ so you'll have access to what's available on the object with the `HassConfig` ty
 
 ### Example Usage
 
-```ts
-function GetConfigExample() {
-  const { getConfig } = useHass();
-  const [state, setState] = useState<string>('UNKNOWN');
-  useEffect(() => {
-    async function fetchConfig() {
-      const config = await getConfig();
-      setState(config.state);
-    }
-    fetchConfig();
-  }, [])
-  return <p>Your home assistant instance is {state}</p>
-}
+<Source dark language="typescript" code={getConfigExample} />

--- a/packages/core/src/hooks/useHass/useHass.getServices.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getServices.mdx
@@ -1,6 +1,7 @@
 import { Source, Meta } from '@storybook/blocks';
+import getServicesExample from './examples/getServices.code?raw';
 
-<Meta title="core/hooks/useHass/getServices" />
+<Meta title="core/hooks/useHass/hass/getServices" />
 
 # getServices()
 This will return all information about your services of your home assistant instance, this is all typed with typescript
@@ -9,21 +10,9 @@ so you'll have access to what's available on the object with the `HassServices` 
 This is useful to know which domains/services you have available to use with `callService`.
 
 ### Definition
-<Source dark language="ts" code={`await getServices()`} />
+<Source dark language="ts" code={`const services = await getServices();`} />
 
 
 ### Example Usage
 
-```ts
-function GetServicesExample() {
-  const { getServices } = useHass();
-  const [services, setServices] = useState<HassServices | null>(null);
-  useEffect(() => {
-    async function fetchServices() {
-      const services = await getServices();
-      setServices(services);
-    }
-    fetchServices();
-  }, [])
-  return <p>{JSON.stringify(services, null, 2)}</p>
-}
+<Source dark language="ts" code={getServicesExample} />

--- a/packages/core/src/hooks/useHass/useHass.getStates.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getStates.mdx
@@ -1,6 +1,7 @@
 import { Source, Meta } from '@storybook/blocks';
+import getStatesExample from './examples/getStates.code?raw';
 
-<Meta title="core/hooks/useHass/getStates" />
+<Meta title="core/hooks/useHass/hass/getStates" />
 
 # getStates()
 This will return all information about your entities with state values of your home assistant instance, this is all typed with typescript
@@ -12,16 +13,4 @@ so you'll have access to what's available on the object with the `HassEntity[]` 
 
 ### Example Usage
 
-```ts
-function GetStatesExample() {
-  const { getStates } = useHass();
-  const [states, setStates] = useState<HassEntity[] | null>(null);
-  useEffect(() => {
-    async function fetchStates() {
-      const states = await getStates();
-      setStates(states);
-    }
-    fetchStates();
-  }, [])
-  return <p>{JSON.stringify(states, null, 2)}</p>
-}
+<Source dark language="ts" code={getStatesExample} />

--- a/packages/core/src/hooks/useHass/useHass.getUser.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getUser.mdx
@@ -1,9 +1,10 @@
 import { Source, Meta } from '@storybook/blocks';
+import getUserExample from './examples/getUser.code?raw';
 
-<Meta title="core/hooks/useHass/getUser" />
+<Meta title="core/hooks/useHass/hass/getUser" />
 
 # getUser()
-This will return all information about your current user of your home assistant instance, this is all typed with typescript
+This will return all information about the current user from the authenticated instance from your Home Assistant instance, this is all typed with typescript
 so you'll have access to what's available on the object with the `HassUser` type.
 
 This may be useful if you want to extract the name or perform different UI updates based on the role of the logged in user.
@@ -14,16 +15,4 @@ This may be useful if you want to extract the name or perform different UI updat
 
 ### Example Usage
 
-```ts
-function GetUserExample() {
-  const { getUser } = useHass();
-  const [user, setUser] = useState<HassUser | null>(null);
-  useEffect(() => {
-    async function fetchUser() {
-      const user = await getUser();
-      setUser(user);
-    }
-    fetchUser();
-  }, [])
-  return <p>{JSON.stringify(user, null, 2)}</p>
-}
+<Source dark language="ts" code={getUserExample} />

--- a/packages/core/src/hooks/useHass/useHass.joinHassUrl.mdx
+++ b/packages/core/src/hooks/useHass/useHass.joinHassUrl.mdx
@@ -1,0 +1,17 @@
+import { Source, Meta } from '@storybook/blocks';
+import joinHassUrlExample from './examples/joinHassUrl.code?raw';
+
+<Meta title="core/hooks/useHass/hass/joinHassUrl" />
+
+# joinHassUrl(path: string)
+This will essentially suffix the hassUrl provided to `HassConnect` with the string provided to the first param.
+
+This may be useful if you want to extract the name or perform different UI updates based on the role of the logged in user.
+
+### Definition
+<Source dark language="ts" code={`const url = joinHassUrl('/something')`} />
+
+
+### Example Usage
+
+<Source dark language="ts" code={joinHassUrlExample} />

--- a/packages/core/src/hooks/useHass/useHass.mdx
+++ b/packages/core/src/hooks/useHass/useHass.mdx
@@ -1,26 +1,14 @@
-import { Meta } from '@storybook/blocks';
+import { Meta, Source } from '@storybook/blocks';
+import useHassExample from './examples/useHass.code?raw';
 
 <Meta title="core/hooks/useHass" />
 
 # useHass()
 This hook will return you a set of functions that you can use to interact with your home assistant instance.
 
-
-This hook should be used inside the context of `<HassConnect />` and not outside of it otherwise it will not have access to
+This hook should be used inside the context of [`<HassConnect />`](/docs/core-hassconnect--docs) and not outside of it otherwise it will not have access to
 the authenticated home assistant API.
 
 ### Example Usage
 
-```ts
-import { HassConnect, useHass } from '@hakit/core';
-function Child() {
-  const hass = useHass();
-  const light = hass.getEntity('light.something');
-  // can now access all properties relating to the light
-  return light.state;
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Child />
-  </HassConnect>
-}
+<Source dark language="ts" code={useHassExample} />

--- a/packages/core/src/hooks/useHass/useHass.useStore.mdx
+++ b/packages/core/src/hooks/useHass/useHass.useStore.mdx
@@ -1,6 +1,7 @@
 import { Source, Meta } from '@storybook/blocks';
+import useStoreExample from './examples/useStore.code?raw';
 
-<Meta title="core/hooks/useHass/useStore" />
+<Meta title="core/hooks/useHass/hass/useStore" />
 
 # useStore(selector: (store: HassStore) => any): any
 This will return all the information from the store, you can also pass through a selector through as the function to only
@@ -9,10 +10,4 @@ subscribe to updates for that particular value.
 
 ### Example Usage
 
-```ts
-function useStoreExample() {
-
-  const { useStore } = useHass();
-  const entities = useStore(store => store.entities);
-  return <p>{JSON.stringify(entities, null, 2)}</p>
-}
+<Source dark language="ts" code={useStoreExample} />

--- a/packages/core/src/hooks/useHistory/examples/useHistory.code.tsx
+++ b/packages/core/src/hooks/useHistory/examples/useHistory.code.tsx
@@ -9,7 +9,7 @@ function Office() {
   })}</p>;
 }
 export function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
     <Office />
   </HassConnect>
 }

--- a/packages/core/src/hooks/useHistory/examples/useHistory.code.tsx
+++ b/packages/core/src/hooks/useHistory/examples/useHistory.code.tsx
@@ -1,15 +1,27 @@
-
-import { HassConnect, useHistory } from '@hakit/core';
+import { HassConnect, useHistory } from "@hakit/core";
 
 function Office() {
-  const history = useHistory('light.some_light');
+  const history = useHistory("light.some_light");
   // can now access all properties relating to the history for this light.
-  return history.loading ? <p>Loading</p> : <p>History: {history.timeline.map((state, index) => {
-    return <p key={index}>{state.state}: {state.last_changed};</p>;
-  })}</p>;
+  return history.loading ? (
+    <p>Loading</p>
+  ) : (
+    <p>
+      History:{" "}
+      {history.timeline.map((state, index) => {
+        return (
+          <p key={index}>
+            {state.state}: {state.last_changed};
+          </p>
+        );
+      })}
+    </p>
+  );
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Office />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Office />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useHistory/examples/useHistory.code.tsx
+++ b/packages/core/src/hooks/useHistory/examples/useHistory.code.tsx
@@ -1,0 +1,15 @@
+
+import { HassConnect, useHistory } from '@hakit/core';
+
+function Office() {
+  const history = useHistory('light.some_light');
+  // can now access all properties relating to the history for this light.
+  return history.loading ? <p>Loading</p> : <p>History: {history.timeline.map((state, index) => {
+    return <p key={index}>{state.state}: {state.last_changed};</p>;
+  })}</p>;
+}
+export function App() {
+  return <HassConnect hassUrl="http://localhost:1234">
+    <Office />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useHistory/useHistoryDocs.mdx
+++ b/packages/core/src/hooks/useHistory/useHistoryDocs.mdx
@@ -1,4 +1,5 @@
 import { Meta, Source } from '@storybook/blocks';
+import useHistoryExample from './examples/useHistory.code?raw';
 
 <Meta title="core/hooks/useHistory" />
 
@@ -13,19 +14,5 @@ This will automatically subscribe/unsubscribe for you so there's no need to mana
 
 ### Example Usage
 
-<Source dark code={`
-import { HassConnect, useHistory } from '@hakit/core';
-function Office() {
-  const history = useHistory('light.some_light');
-  // can now access all properties relating to the history for this light.
-  return <div>
-    DO SOMETHING WITH THE HISTORY!
-  </div>
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Office />
-  </HassConnect>
-}
-`} />
+<Source dark code={useHistoryExample} />
 

--- a/packages/core/src/hooks/useIcon/domains/constants.ts
+++ b/packages/core/src/hooks/useIcon/domains/constants.ts
@@ -81,6 +81,7 @@ export const FIXED_DOMAIN_ICONS = {
   proximity: "mdi:apple-safari",
   remote: "mdi:remote",
   scene: "mdi:palette",
+  media_player: 'mdi:music-box',
   schedule: "mdi:calendar-clock",
   script: "mdi:script-text",
   select: "mdi:format-list-bulleted",

--- a/packages/core/src/hooks/useIcon/domains/constants.ts
+++ b/packages/core/src/hooks/useIcon/domains/constants.ts
@@ -81,7 +81,7 @@ export const FIXED_DOMAIN_ICONS = {
   proximity: "mdi:apple-safari",
   remote: "mdi:remote",
   scene: "mdi:palette",
-  media_player: 'mdi:music-box',
+  media_player: "mdi:music-box",
   schedule: "mdi:calendar-clock",
   script: "mdi:script-text",
   select: "mdi:format-list-bulleted",

--- a/packages/core/src/hooks/useIcon/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/basic.code.tsx
@@ -1,0 +1,6 @@
+import { useIcon } from '@hakit/core';
+
+export function IconExample() {
+  const icon = useIcon('mdi:home');
+  return <div>{icon}</div>
+}

--- a/packages/core/src/hooks/useIcon/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/basic.code.tsx
@@ -1,6 +1,6 @@
-import { useIcon } from '@hakit/core';
+import { useIcon } from "@hakit/core";
 
 export function IconExample() {
-  const icon = useIcon('mdi:home');
-  return <div>{icon}</div>
+  const icon = useIcon("mdi:home");
+  return <div>{icon}</div>;
 }

--- a/packages/core/src/hooks/useIcon/examples/byDomain.basic.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byDomain.basic.code.tsx
@@ -1,0 +1,12 @@
+import { HassConnect, useIconByDomain } from '@hakit/core';
+
+export function IconExample() {
+  const icon = useIconByDomain('light');
+  return <div>{icon}</div>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <IconExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useIcon/examples/byDomain.basic.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byDomain.basic.code.tsx
@@ -1,12 +1,14 @@
-import { HassConnect, useIconByDomain } from '@hakit/core';
+import { HassConnect, useIconByDomain } from "@hakit/core";
 
 export function IconExample() {
-  const icon = useIconByDomain('light');
-  return <div>{icon}</div>
+  const icon = useIconByDomain("light");
+  return <div>{icon}</div>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <IconExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <IconExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useIcon/examples/byDomain.customProps.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byDomain.customProps.code.tsx
@@ -1,17 +1,19 @@
-import { useIconByDomain, HassConnect } from '@hakit/core';
+import { useIconByDomain, HassConnect } from "@hakit/core";
 
 function IconExample() {
-  const icon = useIconByDomain('mediaPlayer', {
-    color: 'red',
+  const icon = useIconByDomain("mediaPlayer", {
+    color: "red",
     style: {
-      fontSize: 40
-    }
+      fontSize: 40,
+    },
   });
-  return <div>{icon}</div>
+  return <div>{icon}</div>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <IconExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <IconExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useIcon/examples/byDomain.customProps.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byDomain.customProps.code.tsx
@@ -1,0 +1,17 @@
+import { useIconByDomain, HassConnect } from '@hakit/core';
+
+function IconExample() {
+  const icon = useIconByDomain('mediaPlayer', {
+    color: 'red',
+    style: {
+      fontSize: 40
+    }
+  });
+  return <div>{icon}</div>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <IconExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useIcon/examples/byEntity.basic.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byEntity.basic.code.tsx
@@ -1,12 +1,14 @@
-import { HassConnect, useIconByEntity } from '@hakit/core';
+import { HassConnect, useIconByEntity } from "@hakit/core";
 
 function IconExample() {
-  const icon = useIconByEntity('light.fake_light_1');
-  return <div>{icon}</div>
+  const icon = useIconByEntity("light.fake_light_1");
+  return <div>{icon}</div>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <IconExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <IconExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useIcon/examples/byEntity.basic.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byEntity.basic.code.tsx
@@ -1,0 +1,12 @@
+import { HassConnect, useIconByEntity } from '@hakit/core';
+
+function IconExample() {
+  const icon = useIconByEntity('light.fake_light_1');
+  return <div>{icon}</div>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <IconExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useIcon/examples/byEntity.customProps.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byEntity.customProps.code.tsx
@@ -1,0 +1,17 @@
+import { useIconByEntity, HassConnect } from '@hakit/core';
+
+function IconExample() {
+  const icon = useIconByEntity('light.fake_light_1', {
+    color: 'red',
+    style: {
+      fontSize: 40
+    }
+  });
+  return <div>{icon}</div>
+}
+
+export function App() {
+  return <HassConnect hassUrl="https://homeassistant.local:8123">
+    <IconExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useIcon/examples/byEntity.customProps.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/byEntity.customProps.code.tsx
@@ -1,17 +1,19 @@
-import { useIconByEntity, HassConnect } from '@hakit/core';
+import { useIconByEntity, HassConnect } from "@hakit/core";
 
 function IconExample() {
-  const icon = useIconByEntity('light.fake_light_1', {
-    color: 'red',
+  const icon = useIconByEntity("light.fake_light_1", {
+    color: "red",
     style: {
-      fontSize: 40
-    }
+      fontSize: 40,
+    },
   });
-  return <div>{icon}</div>
+  return <div>{icon}</div>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="https://homeassistant.local:8123">
-    <IconExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="https://homeassistant.local:8123">
+      <IconExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useIcon/examples/customProps.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/customProps.code.tsx
@@ -1,0 +1,11 @@
+import { useIcon } from '@hakit/core';
+
+export function IconExample() {
+  const icon = useIcon('mdi:home', {
+    color: 'red',
+    style: {
+      fontSize: 40
+    }
+  });
+  return <div>{icon}</div>
+}

--- a/packages/core/src/hooks/useIcon/examples/customProps.code.tsx
+++ b/packages/core/src/hooks/useIcon/examples/customProps.code.tsx
@@ -1,11 +1,11 @@
-import { useIcon } from '@hakit/core';
+import { useIcon } from "@hakit/core";
 
 export function IconExample() {
-  const icon = useIcon('mdi:home', {
-    color: 'red',
+  const icon = useIcon("mdi:home", {
+    color: "red",
     style: {
-      fontSize: 40
-    }
+      fontSize: 40,
+    },
   });
-  return <div>{icon}</div>
+  return <div>{icon}</div>;
 }

--- a/packages/core/src/hooks/useIcon/useIcon.mdx
+++ b/packages/core/src/hooks/useIcon/useIcon.mdx
@@ -1,5 +1,7 @@
 import { Meta, Source } from '@storybook/blocks';
 import { useIcon } from './';
+import basicExample from './examples/basic.code?raw';
+import customPropsExample from './examples/customProps.code?raw';
 
 <Meta title="core/hooks/useIcon" />
 
@@ -11,13 +13,7 @@ To find an available icon name, simply search for an icon on [iconify](https://i
 
 ### Example Usage
 
-<Source dark code={`
-import { useIcon } from '@hakit/core';
-function IconExample() {
-  const icon = useIcon('mdi:home');
-  return <div>{icon}</div>
-}
-`} />
+<Source dark code={basicExample} />
 
 ## Outputs
 
@@ -27,18 +23,7 @@ function IconExample() {
 
 If you want to provide props that the Icon component that [@iconify/react"](https://iconify.design/docs/icon-components/react/) supports, pass it as the second parameter.
 This example will change the color to red and the size to 40px.
-<Source dark code={`
-import { useIcon } from '@hakit/core';
-function IconExample() {
-  const icon = useIcon('mdi:home', {
-    color: 'red',
-    style: {
-      fontSize: 40
-    }
-  });
-  return <div>{icon}</div>
-}
-`} />
+<Source dark code={customPropsExample} />
 
 ## Outputs
 

--- a/packages/core/src/hooks/useIcon/useIconByDomain.mdx
+++ b/packages/core/src/hooks/useIcon/useIconByDomain.mdx
@@ -1,5 +1,7 @@
 import { Meta, Source } from '@storybook/blocks';
 import { useIconByDomain } from './';
+import basic from './examples/byDomain.basic.code?raw';
+import customProps from './examples/byDomain.customProps.code?raw';
 
 <Meta title="core/hooks/useIconByDomain" />
 
@@ -9,13 +11,7 @@ This hook will retrieve an icon by domain from a predefined list of icons.
 
 ### Example Usage
 
-<Source dark code={`
-import { useIconByDomain } from '@hakit/core';
-function IconExample() {
-  const icon = useIconByDomain('light');
-  return <div>{icon}</div>
-}
-`} />
+<Source dark code={basic} />
 
 ## Outputs
 
@@ -25,18 +21,7 @@ function IconExample() {
 
 If you want to provide props that the Icon component that [@iconify/react](https://iconify.design/docs/icon-components/react/) supports, pass it as the second parameter.
 This example will change the color to red and the size to 40px.
-<Source dark code={`
-import { useIconByDomain } from '@hakit/core';
-function IconExample() {
-  const icon = useIconByDomain('mediaPlayer', {
-    color: 'red',
-    style: {
-      fontSize: 40
-    }
-  });
-  return <div>{icon}</div>
-}
-`} />
+<Source dark code={customProps} />
 
 ## Outputs
 

--- a/packages/core/src/hooks/useIcon/useIconByEntity.mdx
+++ b/packages/core/src/hooks/useIcon/useIconByEntity.mdx
@@ -1,4 +1,6 @@
 import { Meta, Source } from '@storybook/blocks';
+import basic from './examples/byEntity.basic.code?raw';
+import customProps from './examples/byEntity.customProps.code?raw';
 
 <Meta title="core/hooks/useIconByEntity" />
 
@@ -10,27 +12,10 @@ To find an available icon name, simply search for an icon on [iconify](https://i
 
 ### Example Usage
 
-<Source dark code={`
-import { useIconByEntity } from '@hakit/core';
-function IconExample() {
-  const icon = useIconByEntity('light.fake_light_1');
-  return <div>{icon}</div>
-}
-`}/>
+<Source dark code={basic}/>
 
 ## Custom Props
 
 If you want to provide props that the Icon component that [@iconify/react](https://iconify.design/docs/icon-components/react/) supports, pass it as the second parameter.
 This example will change the color to red and the size to 40px.
-<Source dark code={`
-import { useIconByEntity } from '@hakit/core';
-function IconExample() {
-  const icon = useIconByEntity('light.fake_light_1', {
-    color: 'red',
-    style: {
-      fontSize: 40
-    }
-  });
-  return <div>{icon}</div>
-}
-`}/>
+<Source dark code={customProps}/>

--- a/packages/core/src/hooks/useLightBrightness/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLightBrightness/examples/basic.code.tsx
@@ -1,0 +1,25 @@
+import { HassConnect, useEntity, useLightBrightness } from '@hakit/core';
+import { Column, LightControls } from '@hakit/components';
+
+export function Dashboard() {
+  const light = useEntity('light.fake_light_1');
+
+  const brightness = useLightBrightness(light);
+  // can now access all properties relating to the weather for this entity.
+  return <Column gap="1rem">
+    <Column gap="1rem" style={{
+      background: light.custom.rgbColor,
+      padding: '20px',
+      color: 'black',
+      filter: `brightness(${brightness}%)`
+    }}>
+      <span>Brightness: {brightness}</span>
+    </Column>
+    <LightControls entity='light.fake_light_1' />
+  </Column>
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <Dashboard />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useLightBrightness/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLightBrightness/examples/basic.code.tsx
@@ -1,25 +1,32 @@
-import { HassConnect, useEntity, useLightBrightness } from '@hakit/core';
-import { Column, LightControls } from '@hakit/components';
+import { HassConnect, useEntity, useLightBrightness } from "@hakit/core";
+import { Column, LightControls } from "@hakit/components";
 
 export function Dashboard() {
-  const light = useEntity('light.fake_light_1');
+  const light = useEntity("light.fake_light_1");
 
   const brightness = useLightBrightness(light);
   // can now access all properties relating to the weather for this entity.
-  return <Column gap="1rem">
-    <Column gap="1rem" style={{
-      background: light.custom.rgbColor,
-      padding: '20px',
-      color: 'black',
-      filter: `brightness(${brightness}%)`
-    }}>
-      <span>Brightness: {brightness}</span>
+  return (
+    <Column gap="1rem">
+      <Column
+        gap="1rem"
+        style={{
+          background: light.custom.rgbColor,
+          padding: "20px",
+          color: "black",
+          filter: `brightness(${brightness}%)`,
+        }}
+      >
+        <span>Brightness: {brightness}</span>
+      </Column>
+      <LightControls entity="light.fake_light_1" />
     </Column>
-    <LightControls entity='light.fake_light_1' />
-  </Column>
+  );
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Dashboard />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useLightBrightness/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightBrightness/examples/primary.stories.tsx
@@ -1,0 +1,32 @@
+import { HassConnect } from 'hass-connect-fake';
+import { ThemeProvider } from '@hakit/components';
+import { Story } from "@storybook/blocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dashboard } from './basic.code';
+
+function Primary() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <ThemeProvider />
+    <Dashboard />
+  </HassConnect>
+}
+
+const meta: Meta<typeof Primary> = {
+  component: Primary,
+};
+
+export default meta;
+type Story = StoryObj<typeof Primary>;
+ 
+export const PrimaryExample: Story = {
+  args: {
+    label: 'PrimaryExample',
+  },
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "none",
+      }
+    }
+  }
+};

--- a/packages/core/src/hooks/useLightBrightness/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightBrightness/examples/primary.stories.tsx
@@ -1,14 +1,16 @@
-import { HassConnect } from 'hass-connect-fake';
-import { ThemeProvider } from '@hakit/components';
+import { HassConnect } from "hass-connect-fake";
+import { ThemeProvider } from "@hakit/components";
 import { Story } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Dashboard } from './basic.code';
+import { Dashboard } from "./basic.code";
 
 function Primary() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <ThemeProvider />
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Dashboard />
+    </HassConnect>
+  );
 }
 
 const meta: Meta<typeof Primary> = {
@@ -17,16 +19,16 @@ const meta: Meta<typeof Primary> = {
 
 export default meta;
 type Story = StoryObj<typeof Primary>;
- 
+
 export const PrimaryExample: Story = {
   args: {
-    label: 'PrimaryExample',
+    label: "PrimaryExample",
   },
   parameters: {
     docs: {
       canvas: {
         sourceState: "none",
-      }
-    }
-  }
+      },
+    },
+  },
 };

--- a/packages/core/src/hooks/useLightBrightness/useLightBrightnessDocs.mdx
+++ b/packages/core/src/hooks/useLightBrightness/useLightBrightnessDocs.mdx
@@ -1,0 +1,30 @@
+import { Meta, Source, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useLightBrightness" />
+
+# useLightBrightness()
+###### `useLightBrightness(entity: HassEntityWithService<"light">)`
+
+The `useLightBrightness` hook is a custom React hook that calculates the brightness percentage of a light entity in a Home Assistant environment.
+
+Here's a detailed description:
+
+- **Input**: The hook takes a single argument, entity, which is an object representing a Home Assistant light entity with its associated services.
+- **Output**: The hook returns a memoized value representing the brightness percentage of the light.
+- **Logic**:
+  - If the light is in the "ON" state, it calculates the brightness percentage by converting the brightness attribute (which ranges from 0 to 255) to a percentage (0 to 100). It ensures that the minimum brightness percentage is 1%.
+  - If the light is not in the "ON" state, it returns 0, indicating that the light is off.
+- **Dependencies**: The memoized value is recalculated whenever the brightness attribute or the state of the entity changes.
+This hook is useful for efficiently managing and displaying the brightness level of a light in a React component, ensuring that the calculation is only performed when necessary.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />
+
+

--- a/packages/core/src/hooks/useLightColor/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLightColor/examples/basic.code.tsx
@@ -1,31 +1,36 @@
-import { ColorPicker, ThemeProvider, Column } from '@hakit/components';
-import { HassConnect, isOffState, useEntity, useLightColor, hs2rgb } from '@hakit/core';
+import { ColorPicker, ThemeProvider, Column } from "@hakit/components";
+import { HassConnect, isOffState, useEntity, useLightColor, hs2rgb } from "@hakit/core";
 
 export function Dashboard() {
-  const light = useEntity('light.fake_light_1');
+  const light = useEntity("light.fake_light_1");
   const { hs } = useLightColor(light);
   if (isOffState(light) || hs === undefined) {
-    return <>
-      Light must be on to calculate colors
-    </>;
+    return <>Light must be on to calculate colors</>;
   }
   // convert the HS to RGB
   const rgb = hs2rgb(hs);
-  return <Column gap="1rem">
-    <Column gap="1rem" style={{
-      background: `rgb(${rgb.join(',')})`,
-      padding: '20px',
-      color: 'black',
-    }}>
-      <span>HS: {hs.map(v => Math.round(v)).join(', ')}</span>
-      <span>RGB: {rgb.map(v => Math.round(v)).join(', ')}</span>
+  return (
+    <Column gap="1rem">
+      <Column
+        gap="1rem"
+        style={{
+          background: `rgb(${rgb.join(",")})`,
+          padding: "20px",
+          color: "black",
+        }}
+      >
+        <span>HS: {hs.map((v) => Math.round(v)).join(", ")}</span>
+        <span>RGB: {rgb.map((v) => Math.round(v)).join(", ")}</span>
+      </Column>
+      <ColorPicker entity="light.fake_light_1" />
     </Column>
-    <ColorPicker entity="light.fake_light_1" />
-  </Column>
+  );
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <ThemeProvider />
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Dashboard />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useLightColor/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLightColor/examples/basic.code.tsx
@@ -1,0 +1,31 @@
+import { ColorPicker, ThemeProvider, Column } from '@hakit/components';
+import { HassConnect, isOffState, useEntity, useLightColor, hs2rgb } from '@hakit/core';
+
+export function Dashboard() {
+  const light = useEntity('light.fake_light_1');
+  const { hs } = useLightColor(light);
+  if (isOffState(light) || hs === undefined) {
+    return <>
+      Light must be on to calculate colors
+    </>;
+  }
+  // convert the HS to RGB
+  const rgb = hs2rgb(hs);
+  return <Column gap="1rem">
+    <Column gap="1rem" style={{
+      background: `rgb(${rgb.join(',')})`,
+      padding: '20px',
+      color: 'black',
+    }}>
+      <span>HS: {hs.map(v => Math.round(v)).join(', ')}</span>
+      <span>RGB: {rgb.map(v => Math.round(v)).join(', ')}</span>
+    </Column>
+    <ColorPicker entity="light.fake_light_1" />
+  </Column>
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <ThemeProvider />
+    <Dashboard />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useLightColor/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightColor/examples/primary.stories.tsx
@@ -1,0 +1,32 @@
+import { HassConnect } from 'hass-connect-fake';
+import { ThemeProvider } from '@hakit/components';
+import { Story } from "@storybook/blocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dashboard } from './basic.code';
+
+function Primary() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <ThemeProvider />
+    <Dashboard />
+  </HassConnect>
+}
+
+const meta: Meta<typeof Primary> = {
+  component: Primary,
+};
+
+export default meta;
+type Story = StoryObj<typeof Primary>;
+ 
+export const PrimaryExample: Story = {
+  args: {
+    label: 'PrimaryExample',
+  },
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "none",
+      }
+    }
+  }
+};

--- a/packages/core/src/hooks/useLightColor/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightColor/examples/primary.stories.tsx
@@ -1,14 +1,16 @@
-import { HassConnect } from 'hass-connect-fake';
-import { ThemeProvider } from '@hakit/components';
+import { HassConnect } from "hass-connect-fake";
+import { ThemeProvider } from "@hakit/components";
 import { Story } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Dashboard } from './basic.code';
+import { Dashboard } from "./basic.code";
 
 function Primary() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <ThemeProvider />
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Dashboard />
+    </HassConnect>
+  );
 }
 
 const meta: Meta<typeof Primary> = {
@@ -17,16 +19,16 @@ const meta: Meta<typeof Primary> = {
 
 export default meta;
 type Story = StoryObj<typeof Primary>;
- 
+
 export const PrimaryExample: Story = {
   args: {
-    label: 'PrimaryExample',
+    label: "PrimaryExample",
   },
   parameters: {
     docs: {
       canvas: {
         sourceState: "none",
-      }
-    }
-  }
+      },
+    },
+  },
 };

--- a/packages/core/src/hooks/useLightColor/useLightColorDocs.mdx
+++ b/packages/core/src/hooks/useLightColor/useLightColorDocs.mdx
@@ -1,0 +1,40 @@
+import { Meta, Source, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useLightColor" />
+
+# useLightColor()
+###### `useLightColor(entity: HassEntityWithService<"light">)`
+
+The `useLightColor` hook in the provided code is a custom React hook that calculates various color-related properties of a light entity in a Home Assistant environment.
+
+Here's a detailed description:
+
+- **Input**: The hook operates on an entity object, which represents a Home Assistant light entity with its associated attributes and state.
+- **Output**: The hook returns an object containing several properties related to the light's color and brightness:
+  - **brightnessAdjusted**: The brightness of the light, adjusted to a percentage scale.
+  - **white**: The white color component of the light.
+  - **coolWhite**: The cool white color component of the light.
+  - **warmWhite**: The warm white color component of the light.
+  - **colorBrightness**: The brightness of the light's color component.
+  - **hs**: The hue and saturation values of the light's color component.
+- **Logic**:
+  - **warmWhite**: Calculates the warm white component of the light if the light is on and in RGBWW color mode. It converts the RGBWW color value to a percentage and then back to a 0-255 scale.
+  - **currentRgbColor**: Retrieves the current RGB color of the light using the getLightCurrentModeRgbColor function.
+  - **colorBrightness**: Calculates the brightness of the light's color component if the light is on. It finds the maximum value among the RGB components, converts it to a percentage, and then back to a 0-255 scale.
+  - **hs**: Converts the RGB color to hue and saturation values if the light is on.
+- **Memoization**: The hook uses useMemo to memoize the calculated values, ensuring that they are only recalculated when the relevant dependencies (entity and currentRgbColor) change. This improves performance by avoiding unnecessary recalculations.
+
+This hook is useful for managing and displaying various color-related properties of a light in a React component, ensuring efficient updates and calculations based on the light's state and attributes.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />
+
+
+

--- a/packages/core/src/hooks/useLightTemperature/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLightTemperature/examples/basic.code.tsx
@@ -1,0 +1,33 @@
+import { HassConnect, isOffState, useEntity, useLightTemperature, temperature2rgb } from '@hakit/core';
+import { Column, ColorTempPicker, ThemeProvider } from '@hakit/components';
+
+
+export function Dashboard() {
+  const light = useEntity('light.fake_light_2');
+  const temperature = useLightTemperature(light);
+  if (isOffState(light) || temperature === undefined) {
+    return <>
+      Light must be on to calculate temperature
+    </>;
+  }
+  // convert the temperature to RGB
+  const rgb = temperature2rgb(temperature);
+  return <Column gap="1rem">
+    <Column gap="1rem" style={{
+      background: `rgb(${rgb.join(',')})`,
+      padding: '20px',
+      color: 'black',
+    }}>
+      <span>Kelvin: {temperature}</span>
+      <span>RGB: {rgb.map(v => Math.round(v)).join(', ')}</span>
+    </Column>
+    <ColorTempPicker entity="light.fake_light_2" />
+  </Column>
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <ThemeProvider />
+    <Dashboard />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useLightTemperature/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLightTemperature/examples/basic.code.tsx
@@ -1,33 +1,37 @@
-import { HassConnect, isOffState, useEntity, useLightTemperature, temperature2rgb } from '@hakit/core';
-import { Column, ColorTempPicker, ThemeProvider } from '@hakit/components';
-
+import { HassConnect, isOffState, useEntity, useLightTemperature, temperature2rgb } from "@hakit/core";
+import { Column, ColorTempPicker, ThemeProvider } from "@hakit/components";
 
 export function Dashboard() {
-  const light = useEntity('light.fake_light_2');
+  const light = useEntity("light.fake_light_2");
   const temperature = useLightTemperature(light);
   if (isOffState(light) || temperature === undefined) {
-    return <>
-      Light must be on to calculate temperature
-    </>;
+    return <>Light must be on to calculate temperature</>;
   }
   // convert the temperature to RGB
   const rgb = temperature2rgb(temperature);
-  return <Column gap="1rem">
-    <Column gap="1rem" style={{
-      background: `rgb(${rgb.join(',')})`,
-      padding: '20px',
-      color: 'black',
-    }}>
-      <span>Kelvin: {temperature}</span>
-      <span>RGB: {rgb.map(v => Math.round(v)).join(', ')}</span>
+  return (
+    <Column gap="1rem">
+      <Column
+        gap="1rem"
+        style={{
+          background: `rgb(${rgb.join(",")})`,
+          padding: "20px",
+          color: "black",
+        }}
+      >
+        <span>Kelvin: {temperature}</span>
+        <span>RGB: {rgb.map((v) => Math.round(v)).join(", ")}</span>
+      </Column>
+      <ColorTempPicker entity="light.fake_light_2" />
     </Column>
-    <ColorTempPicker entity="light.fake_light_2" />
-  </Column>
+  );
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <ThemeProvider />
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Dashboard />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useLightTemperature/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightTemperature/examples/primary.stories.tsx
@@ -1,0 +1,32 @@
+import { HassConnect } from 'hass-connect-fake';
+import { Story } from "@storybook/blocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Dashboard } from './basic.code';
+import { ThemeProvider } from '@hakit/components';
+
+function Primary() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <ThemeProvider />
+    <Dashboard />
+  </HassConnect>
+}
+
+const meta: Meta<typeof Primary> = {
+  component: Primary,
+};
+
+export default meta;
+type Story = StoryObj<typeof Primary>;
+ 
+export const PrimaryExample: Story = {
+  args: {
+    label: 'PrimaryExample',
+  },
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "none",
+      }
+    }
+  }
+};

--- a/packages/core/src/hooks/useLightTemperature/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightTemperature/examples/primary.stories.tsx
@@ -1,14 +1,16 @@
-import { HassConnect } from 'hass-connect-fake';
+import { HassConnect } from "hass-connect-fake";
 import { Story } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Dashboard } from './basic.code';
-import { ThemeProvider } from '@hakit/components';
+import { Dashboard } from "./basic.code";
+import { ThemeProvider } from "@hakit/components";
 
 function Primary() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <ThemeProvider />
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Dashboard />
+    </HassConnect>
+  );
 }
 
 const meta: Meta<typeof Primary> = {
@@ -17,16 +19,16 @@ const meta: Meta<typeof Primary> = {
 
 export default meta;
 type Story = StoryObj<typeof Primary>;
- 
+
 export const PrimaryExample: Story = {
   args: {
-    label: 'PrimaryExample',
+    label: "PrimaryExample",
   },
   parameters: {
     docs: {
       canvas: {
         sourceState: "none",
-      }
-    }
-  }
+      },
+    },
+  },
 };

--- a/packages/core/src/hooks/useLightTemperature/useLightTemperatureDocs.mdx
+++ b/packages/core/src/hooks/useLightTemperature/useLightTemperatureDocs.mdx
@@ -1,0 +1,30 @@
+import { Meta, Source, Story, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useLightTemperature" />
+
+# useLightTemperature()
+###### `useLightTemperature(entity: HassEntityWithService<"light">)`
+
+The `useLightTemperature` hook is a custom React hook that calculates the color temperature of a light entity in a Home Assistant environment.
+
+Here's a detailed description:
+
+- **Input**: The hook takes a single argument, `entity`, which is an object representing a Home Assistant light entity with its associated services.
+- **Output**: The hook returns the color temperature of the light in Kelvin if the light is on and in color temperature mode; otherwise, it returns `undefined`.
+- **Logic**:
+  - The hook uses `useMemo` to memoize the result, ensuring that the calculation is only performed when the relevant dependencies change.
+  - If the light's state is `ON` and its color mode is `COLOR_TEMP`, it returns the `color_temp_kelvin` attribute of the light entity.
+  - If the light is off or not in color temperature mode, it returns `undefined`.
+- **Dependencies**: The memoized value is recalculated whenever the state, `color_mode`, or `color_temp_kelvin` attributes of the entity change.
+
+This hook is useful for efficiently managing and displaying the color temperature of a light in a React component, ensuring that the calculation is only performed when necessary.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />

--- a/packages/core/src/hooks/useLocale/examples/findReplace.code.tsx
+++ b/packages/core/src/hooks/useLocale/examples/findReplace.code.tsx
@@ -1,0 +1,22 @@
+import { HassConnect, localize, useCamera } from "@hakit/core";
+
+export function MyComponent() {
+  const camera = useCamera("camera.mycamera");
+  return (
+    <>
+      {localize("changed_to_state", {
+        search: "{state}",
+        replace: camera.state,
+        fallback: "Camera is not available", // this will be used if \`changed_to_state\` is not available in the locales
+      })}
+    </>
+  );
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <MyComponent />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useLocale/examples/localesConstant.code.tsx
+++ b/packages/core/src/hooks/useLocale/examples/localesConstant.code.tsx
@@ -1,0 +1,15 @@
+import { locales } from "@hakit/core";
+
+async function fetchLocale(languageCode: string) {
+  const locale = locales.find(({ code }) => code === languageCode);
+  if (!locale) {
+    throw new Error(`Locale not found for ${languageCode}`);
+  }
+  const data = await locale.fetch();
+  console.log(data);
+  return data;
+}
+
+fetchLocale("en").then((locale) => {
+  console.log(locale);
+});

--- a/packages/core/src/hooks/useLocale/examples/localizeFunction.code.tsx
+++ b/packages/core/src/hooks/useLocale/examples/localizeFunction.code.tsx
@@ -1,0 +1,15 @@
+// usage with the localize function
+import { HassConnect, localize, type LocaleKeys } from "@hakit/core";
+
+export function MyComponent() {
+  const value = localize("{{selectedKey}}" as LocaleKeys);
+  return <>{value}</>; // should translate to "{{value}}"
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <MyComponent />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useLocale/examples/useLocale.code.tsx
+++ b/packages/core/src/hooks/useLocale/examples/useLocale.code.tsx
@@ -1,0 +1,15 @@
+// usage with the localize function
+import { useLocale, LocaleKeys, HassConnect } from "@hakit/core";
+
+export function MyComponent() {
+  const value = useLocale("{{selectedKey}}" as LocaleKeys);
+  return <>{value}</>; // should translate to "{{value}}"
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <MyComponent />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useLocale/examples/useLocales.code.tsx
+++ b/packages/core/src/hooks/useLocale/examples/useLocales.code.tsx
@@ -1,0 +1,14 @@
+import { useLocales, HassConnect } from "@hakit/core";
+
+export function MyComponent() {
+  const locales = useLocales();
+  return <>{Object.keys(locales).join(", ")}</>;
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <MyComponent />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useLocale/index.ts
+++ b/packages/core/src/hooks/useLocale/index.ts
@@ -18,7 +18,8 @@ interface Options {
   replace?: string;
 }
 
-export function localize(key: LocaleKeys, { search, replace, fallback }: Options = {}): string {
+export function localize(key: LocaleKeys, options?: Options): string {
+  const { search, replace, fallback } = options ?? {};
   if (!LOCALES[key]) {
     if (fallback) {
       return fallback;
@@ -36,8 +37,8 @@ export function useLocales(): Record<LocaleKeys, string> {
   return LOCALES;
 }
 
-export const useLocale = (key: LocaleKeys, options: Options) => {
-  const { fallback = localize("unknown") } = options;
+export const useLocale = (key: LocaleKeys, options?: Options) => {
+  const { fallback = localize("unknown") } = options ?? {};
   const [value, setValue] = useState<string>(fallback);
   const { getConfig } = useHass();
 

--- a/packages/core/src/hooks/useLocale/useLocale.stories.tsx
+++ b/packages/core/src/hooks/useLocale/useLocale.stories.tsx
@@ -18,6 +18,11 @@ import { styled } from "@mui/material/styles";
 import Select, { SelectChangeEvent } from "@mui/material/Select";
 import { VariableSizeList, ListChildComponentProps } from "react-window";
 import { Column, Row } from "@components";
+import useLocaleExample from "./examples/useLocale.code?raw";
+import findReplaceExample from "./examples/findReplace.code?raw";
+import localesConstantExample from "./examples/localesConstant.code?raw";
+import localizeFunctionExample from "./examples/localizeFunction.code?raw";
+import useLocalesExample from "./examples/useLocales.code?raw";
 
 const ITEM_HEIGHT = 48;
 
@@ -195,84 +200,44 @@ function Page() {
           </p>
           <Source
             dark
-            code={`
-// usage with the localize function
-import { localize } from '@hakit/core';
-export function MyComponent() {
-  const value = localize('${selectedKey}');
-  return <>{value}</>; // should translate to "${data?.[selectedKey as LocaleKeys]}"
-}
-      `}
+            code={localizeFunctionExample
+              .replace(" as LocaleKeys", "")
+              .replace(/{{selectedKey}}/g, selectedKey)
+              .replace(/{{value}}/g, data?.[selectedKey as LocaleKeys] || "")}
           />
           <p>You can also use the useLocale hook which is less likely to be something you&apos;ll use but it is available.</p>
           <Source
             dark
-            code={`
-// usage with the localize function
-import { useLocale } from '@hakit/core';
-export function MyComponent() {
-  const value = useLocale('${selectedKey}');
-  return <>{value}</>; // should translate to "${data?.[selectedKey as LocaleKeys]}"
-}
-      `}
+            code={useLocaleExample
+              .replace(" as LocaleKeys", "")
+              .replace(/{{selectedKey}}/g, selectedKey)
+              .replace(/{{value}}/g, data?.[selectedKey as LocaleKeys] || "")}
           />
         </>
       )}
 
-      <h2>Examples</h2>
+      <h2>useLocales hook</h2>
       <p>
         This hook will simply return all available locales retrieved from Home Assistant, you don&apos;t need to use this hook at all unless
         you want to transform the value or inspect all values available. You can use the `localize` method directly anywhere in your
         application.
       </p>
-      <Source
-        dark
-        code={`
-  import { useLocales } from '@hakit/core';
-  export function MyComponent() {
-  const locales = useLocales();
-  return <>{Object.keys(locales).join(', ')}</>;
-  }
-      `}
-      />
+      <Source dark code={useLocalesExample} />
+
+      <h3>Find and replace</h3>
 
       <p>If you want to find/replace a value that&apos;s expected to be dynamic as it might contain a value wrapped in curly braces:</p>
-      <Source
-        dark
-        code={`
-  import { localize, useCalendar } from '@hakit/core';
-  export function MyComponent() {
-  const calendar = useCalendar('calendar.mycal');
-  return <>{localize('panel.calendar', {
-  search: '{state}',
-  replace: calendar.state,
-  fallback: 'Calendar is not available' // this will be used if \`panel.calendar\` is not available in the locales
-  })}</>;
-  }
-      `}
-      />
-
+      <Source dark code={findReplaceExample} />
+      <h3>Fetch Locales</h3>
       <p>
         This is a list of all the available locales, including their hash names, but also including a fetch method which will download the
         assets and cache locally
       </p>
-      <p>
-        Note: This is an example, you do NOT need to do this, it&apos;s automatically handled through HassConnect and retrieved from your
+      <blockquote>
+        <b>NOTE:</b> This is an example, you do NOT need to do this, it&apos;s automatically handled through HassConnect and retrieved from your
         home assistant instance.
-      </p>
-      <Source
-        dark
-        code={`
-  import { locales } from '@hakit/core';
-  const locale = locales.find(({ code }) => code === 'en');
-
-  async function fetchEnLocale() {
-  const data = await locale.fetch();
-  console.log(data)
-  return data;
-  }
-    `}
-      />
+      </blockquote>
+      <Source dark code={localesConstantExample} />
       <p>
         Most of the time, what&apos;s available may work just fine for you, however if you want to replace the locales that the localize
         function uses across the board, you can call `updateLocales` manually, however this will not update the types for LocaleKeys so

--- a/packages/core/src/hooks/useLogs/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLogs/examples/basic.code.tsx
@@ -1,16 +1,20 @@
-import { HassConnect, useLogs } from '@hakit/core';
+import { HassConnect, useLogs } from "@hakit/core";
 
 function Office() {
-  const logs = useLogs('light.some_light');
+  const logs = useLogs("light.some_light");
   // can now access all properties relating to the logs for this light.
-  return <div>
-    There are {logs.length} logs for this light.
-    {JSON.stringify(logs, null, 2)}
-  </div>
+  return (
+    <div>
+      There are {logs.length} logs for this light.
+      {JSON.stringify(logs, null, 2)}
+    </div>
+  );
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Office />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Office />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useLogs/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLogs/examples/basic.code.tsx
@@ -1,0 +1,16 @@
+import { HassConnect, useLogs } from '@hakit/core';
+
+function Office() {
+  const logs = useLogs('light.some_light');
+  // can now access all properties relating to the logs for this light.
+  return <div>
+    There are {logs.length} logs for this light.
+    {JSON.stringify(logs, null, 2)}
+  </div>
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <Office />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useLogs/useLogsDocs.mdx
+++ b/packages/core/src/hooks/useLogs/useLogsDocs.mdx
@@ -1,4 +1,5 @@
 import { Meta, Source } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
 
 <Meta title="core/hooks/useLogs" />
 
@@ -6,26 +7,12 @@ import { Meta, Source } from '@storybook/blocks';
 ###### `useLogs(entityId: EntityName, options: UseLogOptions)`
 This hook is designed to retrieve the current log information from the entitiy if available.
 
-<b>NOTE:</b> This hook is already connected to the Modal via the LogBookRenderer component.
+> <b>NOTE:</b> This hook is already connected to the Modal via the LogBookRenderer component.
 
-This will automatically subscribe/unsubscribe for you so there's no need to manage anything.
+> This will automatically subscribe/unsubscribe for you so there's no need to manage anything.
 
 
 ### Example Usage
 
-<Source dark code={`
-import { HassConnect, useLogs } from '@hakit/core';
-function Office() {
-  const logs = useLogs('light.some_light');
-  // can now access all properties relating to the logs for this light.
-  return <div>
-    DO SOMETHING WITH THE LOGS!
-  </div>
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Office />
-  </HassConnect>
-}
-`} />
+<Source dark code={basicExample} />
 

--- a/packages/core/src/hooks/useLowDevices/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useLowDevices/examples/basic.code.tsx
@@ -1,0 +1,33 @@
+import { useLowDevices, HassConnect, type EntityName } from "@hakit/core";
+import { EntitiesCard, EntitiesCardRow, ThemeProvider } from "@hakit/components";
+
+export function RenderDevices() {
+  const devices = useLowDevices();
+  return (
+    <EntitiesCard includeLastUpdated>
+      {devices.map((device) => (
+        <EntitiesCardRow
+          key={device.entity_id}
+          entity={device.entity_id as EntityName}
+          renderState={(entity) => {
+            return (
+              <div>
+                {entity.state}
+                {entity.attributes.unit_of_measurement}
+              </div>
+            );
+          }}
+        />
+      ))}
+    </EntitiesCard>
+  );
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <RenderDevices />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useLowDevices/useLowDevices.stories.tsx
+++ b/packages/core/src/hooks/useLowDevices/useLowDevices.stories.tsx
@@ -1,31 +1,9 @@
 import { Story, Source, Title, Description, ArgTypes } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useLowDevices } from "@hakit/core";
-import type { EntityName } from "@hakit/core";
-import { EntitiesCard, EntitiesCardRow, ThemeProvider, Row, Column } from "@components";
+import { ThemeProvider, Row, Column } from "@components";
 import { HassConnect } from "@hass-connect-fake";
-
-function RenderDevices() {
-  const devices = useLowDevices();
-  return (
-    <EntitiesCard includeLastUpdated>
-      {devices.map((device) => (
-        <EntitiesCardRow
-          key={device.entity_id}
-          entity={device.entity_id as EntityName}
-          renderState={(entity) => {
-            return (
-              <div>
-                {entity.state}
-                {entity.attributes.unit_of_measurement}
-              </div>
-            );
-          }}
-        />
-      ))}
-    </EntitiesCard>
-  );
-}
+import basicExample from "./examples/basic.code?raw";
+import { RenderDevices } from "./examples/basic.code";
 
 function Template() {
   return (
@@ -61,29 +39,7 @@ export default {
           <ArgTypes />
           <Template />
           <p>Here&apos;s the source code for the above EntitiesCard:</p>
-          <Source
-            dark
-            code={`
-import { useLowDevices } from "@hakit/core";
-function RenderDevices() {
-  const devices = useLowDevices();
-  return (
-    <EntitiesCard
-      includeLastUpdated
-    >
-      {devices.map(device => <EntitiesCardRow key={device.entity_id} entity={device.entity_id as EntityName} renderState={(entity) => {
-        return (
-          <div>
-            {entity.state}
-            {entity.attributes.unit_of_measurement}
-          </div>
-        );
-      }} />)}
-    </EntitiesCard>
-  );
-}
-          `}
-          />
+          <Source dark code={basicExample} />
         </>
       ),
       description: {

--- a/packages/core/src/hooks/useService/examples/preferred.code.tsx
+++ b/packages/core/src/hooks/useService/examples/preferred.code.tsx
@@ -1,11 +1,13 @@
-import { HassConnect, useEntity } from '@hakit/core';
+import { HassConnect, useEntity } from "@hakit/core";
 
 function UseServiceExample() {
-  const entity = useEntity('light.some_light_entity');
-  return <button onClick={() => entity.service.toggle()} >TOGGLE LIGHT</button>
+  const entity = useEntity("light.some_light_entity");
+  return <button onClick={() => entity.service.toggle()}>TOGGLE LIGHT</button>;
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <UseServiceExample />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <UseServiceExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useService/examples/preferred.code.tsx
+++ b/packages/core/src/hooks/useService/examples/preferred.code.tsx
@@ -4,9 +4,8 @@ function UseServiceExample() {
   const entity = useEntity('light.some_light_entity');
   return <button onClick={() => entity.service.toggle()} >TOGGLE LIGHT</button>
 }
-
 export function App() {
   return <HassConnect hassUrl="http://homeassistant.local:8123">
     <UseServiceExample />
   </HassConnect>
-} 
+}

--- a/packages/core/src/hooks/useService/examples/response.code.tsx
+++ b/packages/core/src/hooks/useService/examples/response.code.tsx
@@ -1,5 +1,5 @@
-import { HassConnect, useService } from '@hakit/core';
-import { useState, useCallback } from 'react';
+import { HassConnect, useService } from "@hakit/core";
+import { useState, useCallback } from "react";
 
 interface CalendarEvent {
   description: string;
@@ -10,19 +10,19 @@ interface CalendarEvent {
 interface CalendarResponse {
   "calendar.some_calendar": {
     events: CalendarEvent[];
-  }
+  };
 }
 function UseServiceExample() {
-  const service = useService('calendar');
+  const service = useService("calendar");
   const [events, setEvents] = useState<CalendarEvent[]>([]);
-  const getEvents = useCallback(async() => {
+  const getEvents = useCallback(async () => {
     const events = await service.getEvents<CalendarResponse>({
-      target: 'calendar.some_calendar',
+      target: "calendar.some_calendar",
       serviceData: {
-        start_date_time: '2024-12-22 20:00:00',
+        start_date_time: "2024-12-22 20:00:00",
         duration: {
-          days: 24
-        }
+          days: 24,
+        },
       },
       returnResponse: true,
     });
@@ -36,7 +36,9 @@ function UseServiceExample() {
   );
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <UseServiceExample />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <UseServiceExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useService/examples/response.code.tsx
+++ b/packages/core/src/hooks/useService/examples/response.code.tsx
@@ -1,0 +1,42 @@
+import { HassConnect, useService } from '@hakit/core';
+import { useState, useCallback } from 'react';
+
+interface CalendarEvent {
+  description: string;
+  end: string;
+  start: string;
+  summary: string;
+}
+interface CalendarResponse {
+  "calendar.some_calendar": {
+    events: CalendarEvent[];
+  }
+}
+function UseServiceExample() {
+  const service = useService('calendar');
+  const [events, setEvents] = useState<CalendarEvent[]>([]);
+  const getEvents = useCallback(async() => {
+    const events = await service.getEvents<CalendarResponse>({
+      target: 'calendar.some_calendar',
+      serviceData: {
+        start_date_time: '2024-12-22 20:00:00',
+        duration: {
+          days: 24
+        }
+      },
+      returnResponse: true,
+    });
+    setEvents(events.response["calendar.some_calendar"].events);
+  }, [service]);
+  return (
+    <>
+      <p>There are {events.length} events</p>
+      <button onClick={getEvents}>GET CALENDAR EVENTS</button>
+    </>
+  );
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <UseServiceExample />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useService/examples/rootLevel.code.tsx
+++ b/packages/core/src/hooks/useService/examples/rootLevel.code.tsx
@@ -1,0 +1,20 @@
+import { HassConnect, useService } from '@hakit/core';
+function UseServiceExample() {
+  const api = useService();
+  return (
+   <>
+    <button onClick={() => api('light').toggle({
+        target: 'light.some_light_entity',
+      })}>TOGGLE LIGHT</button>
+      <button onClick={() => api('switch').toggle({
+        target: 'switch.some_switch_entity'
+      })}>TOGGLE SWITCH</button>
+   </>
+  );
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <UseServiceExample />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useService/examples/rootLevel.code.tsx
+++ b/packages/core/src/hooks/useService/examples/rootLevel.code.tsx
@@ -1,20 +1,34 @@
-import { HassConnect, useService } from '@hakit/core';
+import { HassConnect, useService } from "@hakit/core";
 function UseServiceExample() {
   const api = useService();
   return (
-   <>
-    <button onClick={() => api('light').toggle({
-        target: 'light.some_light_entity',
-      })}>TOGGLE LIGHT</button>
-      <button onClick={() => api('switch').toggle({
-        target: 'switch.some_switch_entity'
-      })}>TOGGLE SWITCH</button>
-   </>
+    <>
+      <button
+        onClick={() =>
+          api("light").toggle({
+            target: "light.some_light_entity",
+          })
+        }
+      >
+        TOGGLE LIGHT
+      </button>
+      <button
+        onClick={() =>
+          api("switch").toggle({
+            target: "switch.some_switch_entity",
+          })
+        }
+      >
+        TOGGLE SWITCH
+      </button>
+    </>
   );
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <UseServiceExample />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <UseServiceExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useService/examples/rootTarget.code.tsx
+++ b/packages/core/src/hooks/useService/examples/rootTarget.code.tsx
@@ -1,0 +1,12 @@
+import { HassConnect, useService } from '@hakit/core';
+function UseServiceExample() {
+  const lightService = useService('light', 'light.some_light_entity');
+  return (
+    <button onClick={() => lightService.toggle()}>TOGGLE LIGHT</button>
+  );
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <UseServiceExample />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useService/examples/rootTarget.code.tsx
+++ b/packages/core/src/hooks/useService/examples/rootTarget.code.tsx
@@ -1,12 +1,12 @@
-import { HassConnect, useService } from '@hakit/core';
+import { HassConnect, useService } from "@hakit/core";
 function UseServiceExample() {
-  const lightService = useService('light', 'light.some_light_entity');
-  return (
-    <button onClick={() => lightService.toggle()}>TOGGLE LIGHT</button>
-  );
+  const lightService = useService("light", "light.some_light_entity");
+  return <button onClick={() => lightService.toggle()}>TOGGLE LIGHT</button>;
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <UseServiceExample />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <UseServiceExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useService/examples/serviceLevel.code.tsx
+++ b/packages/core/src/hooks/useService/examples/serviceLevel.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useService } from '@hakit/core';
+function UseServiceExample() {
+  const lightService = useService('light');
+  return (
+    <button onClick={() => lightService.toggle({
+      target: 'light.some_light_entity'
+    })}>TOGGLE LIGHT</button>
+  );
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <UseServiceExample />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useService/examples/serviceLevel.code.tsx
+++ b/packages/core/src/hooks/useService/examples/serviceLevel.code.tsx
@@ -1,14 +1,22 @@
-import { HassConnect, useService } from '@hakit/core';
+import { HassConnect, useService } from "@hakit/core";
 function UseServiceExample() {
-  const lightService = useService('light');
+  const lightService = useService("light");
   return (
-    <button onClick={() => lightService.toggle({
-      target: 'light.some_light_entity'
-    })}>TOGGLE LIGHT</button>
+    <button
+      onClick={() =>
+        lightService.toggle({
+          target: "light.some_light_entity",
+        })
+      }
+    >
+      TOGGLE LIGHT
+    </button>
   );
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <UseServiceExample />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <UseServiceExample />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useService/useService.mdx
+++ b/packages/core/src/hooks/useService/useService.mdx
@@ -1,5 +1,9 @@
 import { Source, Meta } from '@storybook/blocks';
 import responseExample from './examples/response.code?raw';
+import preferredExample from './examples/preferred.code?raw';
+import serviceLevel from './examples/serviceLevel.code?raw';
+import rootLevel from './examples/rootLevel.code?raw';
+import rootTarget from './examples/rootTarget.code?raw';
 
 <Meta title="core/hooks/useService" />
 
@@ -20,70 +24,19 @@ the authenticated home assistant API.
 The `useService()` hook is integrated with the `useEntity` hook so you can use it directly from the entity object.
 Everything is typed so it makes it very easy to use and develop with.
 
-<Source dark code={`
-import { HassConnect, useService } from '@hakit/core';
-function UseServiceExample() {
-  const entity = useEntity('light.some_light_entity');
-  return <button onClick={() => entity.service.toggle()} >TOGGLE LIGHT</button>
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <UseServiceExample />
-  </HassConnect>
-}
-`} />
+<Source dark code={preferredExample} />
 
 ### Service level usage
 We can use the hook to retrieve all the available services for a specific domain, eg "light, mediaPlayer etc...".
-<Source dark code={`
-import { HassConnect, useService } from '@hakit/core';
-function UseServiceExample() {
-  const lightService = useService('light');
-  return (
-    <button onClick={() => lightService.toggle({
-      target: 'light.some_light_entity'
-    })}>TOGGLE LIGHT</button>
-  );
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <UseServiceExample />
-  </HassConnect>
-}
-`} />
+<Source dark code={serviceLevel} />
 
 ## Root level usage
 We can also use the hook to retrieve all the available services and use them as needed.
-<Source dark code={`
-import { HassConnect, useService } from '@hakit/core';
-function UseServiceExample() {
-  const api = useService();
-  return (
-    <button onClick={() => api('light').toggle({
-      target: 'light.some_light_entity',
-    })}>TOGGLE LIGHT</button>
-    <button onClick={() => api('switch').toggle({
-      target: 'switch.some_switch_entity'
-    })}>TOGGLE SWITCH</button>
-  );
-}`} />
+<Source dark code={rootLevel} />
 
 ## Attach entity to root hook
 We can use the `rootTarget` param to tell the hook that every call will be bound to one particular entity.
-<Source dark code={`
-import { HassConnect, useService } from '@hakit/core';
-function UseServiceExample() {
-  const lightService = useService('light', 'light.some_light_entity');
-  return (
-    <button onClick={() => lightService.toggle()}>TOGGLE LIGHT</button>
-  );
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <UseServiceExample />
-  </HassConnect>
-}
-`} />
+<Source dark code={rootTarget} />
 
 ## Returning a response
 Some services return a response, like the calendar `getEvents` service, you can access this response value by adding `returnResponse` to the service call.

--- a/packages/core/src/hooks/useService/useService.mdx
+++ b/packages/core/src/hooks/useService/useService.mdx
@@ -1,4 +1,5 @@
 import { Source, Meta } from '@storybook/blocks';
+import responseExample from './examples/response.code?raw';
 
 <Meta title="core/hooks/useService" />
 
@@ -6,13 +7,13 @@ import { Source, Meta } from '@storybook/blocks';
 ###### `useService(domain?: SnakeOrCamelDomain, rootTarget?: Target)`
 This hook is designed to make it easy to make service calls programmatically.
 
-This is a memoized wrapper for the [callService()](/docs/core-hooks-usehass-callservice--docs) helper from [useHass()](/docs/core-hooks-usehass--docs) to make it
+This is a memoized wrapper for the [callService()](/docs/core-hooks-usehass-hass-callservice--docs) helper from [useHass()](/docs/core-hooks-usehass--docs) to make it
 easier to call services.
 
 **Note:** There's extensive types available for typescript developers to make it very easy to develop and call actions with the available types for different
 services, if a service isn't available in the types or the params are different / incorrect to what you're expecting you can extend these [here](/docs/introduction-typescriptsync--docs).
 
-This hook should be used inside the context of `<HassConnect />` and not outside of it otherwise it will not have access to
+This hook should be used inside the context of [`<HassConnect />`](/docs/core-hassconnect--docs) and not outside of it otherwise it will not have access to
 the authenticated home assistant API.
 
 ### Preferred usage
@@ -88,43 +89,4 @@ function App() {
 Some services return a response, like the calendar `getEvents` service, you can access this response value by adding `returnResponse` to the service call.
 The response object type is able to be defined by passing a generic type to the service call itself, see example below:
 
-<Source dark code={`
-import { HassConnect, useService } from '@hakit/core';
-import { useState, useCallback } from 'react';
-interface CalendarEvent {
-  description: string;
-  end: string;
-  start: string;
-  summary: string;
-}
-interface CalendarResponse {
-  "calendar.some_calendar": {
-    events: CalendarEvent[];
-  }
-}
-function UseServiceExample() {
-  const [events, setEvents] = useState<CalendarEvent[]>([]);
-  const getEvents = useCallback(async() => {
-    const events = await service.getEvents<CalendarResponse>({
-      target: 'calendar.some_calendar',
-      serviceData: {
-        start_date_time: '2024-12-22 20:00:00',
-        duration: {
-          days: 24
-        }
-      },
-      returnResponse: true,
-    });
-    setEvents(events.response["calendar.some_calendar"].events);
-  }, [service]);
-  return (
-    <p>There are {events.length} events</p>
-    <button onClick={getEvents}>GET CALENDAR EVENTS</button>
-  );
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <UseServiceExample />
-  </HassConnect>
-}
-`} />
+<Source dark code={responseExample} />

--- a/packages/core/src/hooks/useSubscribeEntity/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useSubscribeEntity/examples/basic.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useSubscribeEntity } from '@hakit/core';
+
+function Office() {
+  const getEntity = useSubscribeEntity('light.some_light');
+  const entity = getEntity();
+  return <div>
+    {entity?.state}
+  </div>
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <Office />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useSubscribeEntity/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useSubscribeEntity/examples/basic.code.tsx
@@ -1,14 +1,14 @@
-import { HassConnect, useSubscribeEntity } from '@hakit/core';
+import { HassConnect, useSubscribeEntity } from "@hakit/core";
 
 function Office() {
-  const getEntity = useSubscribeEntity('light.some_light');
+  const getEntity = useSubscribeEntity("light.some_light");
   const entity = getEntity();
-  return <div>
-    {entity?.state}
-  </div>
+  return <div>{entity?.state}</div>;
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Office />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Office />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useSubscribeEntity/useSubscribeEntity.mdx
+++ b/packages/core/src/hooks/useSubscribeEntity/useSubscribeEntity.mdx
@@ -1,4 +1,5 @@
 import { Meta, Source } from '@storybook/blocks';
+import basicExample from './examples//basic.code?raw';
 
 <Meta title="core/hooks/useSubscribeEntity" />
 
@@ -10,19 +11,5 @@ This will subscribe to a single entity and only return an updated getEntity func
 
 ### Example Usage
 
-<Source dark code={`
-import { HassConnect, useSubscribeEntity } from '@hakit/core';
-function Office() {
-  const getEntity = useSubscribeEntity('light.some_light');
-  const entity = getEntity();
-  return <div>
-    {entity.state}
-  </div>
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Office />
-  </HassConnect>
-}
-`} />
+<Source dark code={basicExample} />
 

--- a/packages/core/src/hooks/useTemplate/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useTemplate/examples/basic.code.tsx
@@ -1,0 +1,19 @@
+import { useTemplate, HassConnect } from "@hakit/core";
+import { templateCodeToProcess } from "./constants";
+
+function RenderCustomTemplate() {
+  const template = useTemplate({
+    template: templateCodeToProcess,
+    variables: { entity_id: 'light.fake_light_1' }
+  });
+  
+  return <>
+    Template result: {template ?? 'loading'}
+  </>
+}
+
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <RenderCustomTemplate />
+  </HassConnect>;
+}

--- a/packages/core/src/hooks/useTemplate/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useTemplate/examples/basic.code.tsx
@@ -4,16 +4,16 @@ import { templateCodeToProcess } from "./constants";
 function RenderCustomTemplate() {
   const template = useTemplate({
     template: templateCodeToProcess,
-    variables: { entity_id: 'light.fake_light_1' }
+    variables: { entity_id: "light.fake_light_1" },
   });
-  
-  return <>
-    Template result: {template ?? 'loading'}
-  </>
+
+  return <>Template result: {template ?? "loading"}</>;
 }
 
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <RenderCustomTemplate />
-  </HassConnect>;
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <RenderCustomTemplate />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useTemplate/examples/constants.ts
+++ b/packages/core/src/hooks/useTemplate/examples/constants.ts
@@ -1,0 +1,8 @@
+
+export const templateCodeToProcess = `
+  {% if is_state(entity_id, "on") %}
+    The entity is on!!
+  {% else %}
+    The entity is not on!!
+  {% endif %}
+`;

--- a/packages/core/src/hooks/useTemplate/examples/constants.ts
+++ b/packages/core/src/hooks/useTemplate/examples/constants.ts
@@ -1,4 +1,3 @@
-
 export const templateCodeToProcess = `
   {% if is_state(entity_id, "on") %}
     The entity is on!!

--- a/packages/core/src/hooks/useTemplate/examples/simple.code.tsx
+++ b/packages/core/src/hooks/useTemplate/examples/simple.code.tsx
@@ -1,4 +1,4 @@
-import { useTemplate } from '@hakit/core';
+import { useTemplate } from "@hakit/core";
 
 export function Component() {
   // use within HassConnect context!

--- a/packages/core/src/hooks/useTemplate/examples/simple.code.tsx
+++ b/packages/core/src/hooks/useTemplate/examples/simple.code.tsx
@@ -1,0 +1,9 @@
+import { useTemplate } from '@hakit/core';
+
+export function Component() {
+  // use within HassConnect context!
+  const template = useTemplate({
+    template: '{{ is_state_attr("climate.air_conditioner", "state", "heat") }}',
+  });
+  return template;
+}

--- a/packages/core/src/hooks/useTemplate/useTemplate.stories.tsx
+++ b/packages/core/src/hooks/useTemplate/useTemplate.stories.tsx
@@ -3,10 +3,9 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useTemplate, useEntity } from "@hakit/core";
 import { ThemeProvider, Column, Alert, Row, FabCard } from "@components";
 import { HassConnect } from "@hass-connect-fake";
-import { templateCodeToProcess } from './examples/constants';
-import basicExample from './examples/basic.code?raw';
-import simpleExample from './examples/simple.code?raw';
-
+import { templateCodeToProcess } from "./examples/constants";
+import basicExample from "./examples/basic.code?raw";
+import simpleExample from "./examples/simple.code?raw";
 
 function SubscribeTemplateExample() {
   const entity = useEntity("light.fake_light_1");
@@ -65,10 +64,7 @@ export default {
           <Description />
           <ArgTypes />
           <p>The following is the use of the hook in it&apos;s default form:</p>
-          <Source
-            dark
-            code={simpleExample}
-          />
+          <Source dark code={simpleExample} />
           <p>Here&apos;s a working example of how this hook functions when connected to entities:</p>
           <Template />
         </>

--- a/packages/core/src/hooks/useTemplate/useTemplate.stories.tsx
+++ b/packages/core/src/hooks/useTemplate/useTemplate.stories.tsx
@@ -3,34 +3,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { useTemplate, useEntity } from "@hakit/core";
 import { ThemeProvider, Column, Alert, Row, FabCard } from "@components";
 import { HassConnect } from "@hass-connect-fake";
+import { templateCodeToProcess } from './examples/constants';
+import basicExample from './examples/basic.code?raw';
+import simpleExample from './examples/simple.code?raw';
 
-const templateCodeToProcess = `
-{% if is_state(entity_id, "on") %}
-  The entity is on!!
-{% else %}
-  The entity is not on!!
-{% endif %}
-`;
-
-const exampleUsage = `
-import { useTemplate, HassConnect } from "@hakit/core";
-function RenderCustomTemplate() {
-  const template = useTemplate({
-    template: templateCodeToProcess,
-    variables: { entity_id: 'light.fake_light_1' }
-  });
-  return <>
-    Template result: {template ?? 'loading'}
-  </>
-}\n
-function App() {
-  return (
-    <HassConnect hassUrl="http://homeassistant.local:8123">
-      <RenderCustomTemplate />
-    </HassConnect>
-  );
-}
-`;
 
 function SubscribeTemplateExample() {
   const entity = useEntity("light.fake_light_1");
@@ -56,7 +32,7 @@ function SubscribeTemplateExample() {
       <Source dark code={`// templateCodeToProcess\r${templateCodeToProcess}`} />
       <Alert type="info" title={`Template result: ${template ?? "loading"}`} />
       <Alert type="warning" title="Here's the source code for the above template example:" cssStyles={`margin-top: 2rem;`} />
-      <Source dark code={exampleUsage} />
+      <Source dark code={basicExample} />
     </Column>
   );
 }
@@ -91,9 +67,7 @@ export default {
           <p>The following is the use of the hook in it&apos;s default form:</p>
           <Source
             dark
-            code={`// use within HassConnect context!\nconst template = useTemplate({
-  template: '{{ is_state_attr("climate.air_conditioner", "state", "heat") }}',
-});`}
+            code={simpleExample}
           />
           <p>Here&apos;s a working example of how this hook functions when connected to entities:</p>
           <Template />

--- a/packages/core/src/hooks/useWeather/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useWeather/examples/basic.code.tsx
@@ -1,14 +1,14 @@
-import { HassConnect, useWeather } from '@hakit/core';
+import { HassConnect, useWeather } from "@hakit/core";
 
 function Dashboard() {
-  const weatherEntity = useWeather('weather.weather_entity');
+  const weatherEntity = useWeather("weather.weather_entity");
   // can now access all properties relating to the weather for this entity.
-  return <div>
-    {JSON.stringify(weatherEntity.forecast, null, 2)}
-  </div>
+  return <div>{JSON.stringify(weatherEntity.forecast, null, 2)}</div>;
 }
 export function App() {
-  return <HassConnect hassUrl="http://homeassistant.local:8123">
-    <Dashboard />
-  </HassConnect>
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Dashboard />
+    </HassConnect>
+  );
 }

--- a/packages/core/src/hooks/useWeather/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useWeather/examples/basic.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useWeather } from '@hakit/core';
+
+function Dashboard() {
+  const weatherEntity = useWeather('weather.weather_entity');
+  // can now access all properties relating to the weather for this entity.
+  return <div>
+    {JSON.stringify(weatherEntity.forecast, null, 2)}
+  </div>
+}
+export function App() {
+  return <HassConnect hassUrl="http://homeassistant.local:8123">
+    <Dashboard />
+  </HassConnect>
+}

--- a/packages/core/src/hooks/useWeather/useWeatherDocs.mdx
+++ b/packages/core/src/hooks/useWeather/useWeatherDocs.mdx
@@ -1,4 +1,5 @@
 import { Meta, Source } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
 
 <Meta title="core/hooks/useWeather" />
 
@@ -7,26 +8,13 @@ import { Meta, Source } from '@storybook/blocks';
 This hook is designed to extend the current entity with the current weather information from the entitiy if available.
 This will add a "forecast" property to the entity which will contain the current weather information including the type of (daily, twice_daily or hourly)
 
-<b>NOTE:</b> This hook is already connected to the weather card!
+> <b>NOTE:</b> This hook is already connected to the weather card!
 
-This will automatically subscribe/unsubscribe for you so there's no need to manage anything.
-
+> This will automatically subscribe/unsubscribe for you so there's no need to manage anything.
 
 ### Example Usage
 
-<Source dark code={`
-import { HassConnect, useWeather } from '@hakit/core';
-function Dashboard() {
-  const weatherEntity = useWeather('weather.weather_entity');
-  // can now access all properties relating to the weather for this entity.
-  return <div>
-    {JSON.stringify(weatherEntity.forecast, null, 2)}
-  </div>
-}
-function App() {
-  return <HassConnect hassUrl="http://localhost:1234">
-    <Dashboard />
-  </HassConnect>
-}
-`} />
+<Source dark code={basicExample} />
+
+
 

--- a/packages/core/src/types/supported-services.ts
+++ b/packages/core/src/types/supported-services.ts
@@ -2,32 +2,6 @@
 
 import type { ServiceFunctionTypes, ServiceFunction } from "./";
 export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
-  persistentNotification: {
-    // Shows a notification on the notifications panel.
-    create: ServiceFunction<
-      object,
-      T,
-      {
-        // Message body of the notification. @example Please check your configuration.yaml.
-        message: string;
-        // Optional title of the notification. @example Test notification
-        title?: string;
-        // ID of the notification. This new notification will overwrite an existing notification with the same ID. @example 1234
-        notification_id?: string;
-      }
-    >;
-    // Deletes a notification from the notifications panel.
-    dismiss: ServiceFunction<
-      object,
-      T,
-      {
-        // ID of the notification to be deleted. @example 1234
-        notification_id: string;
-      }
-    >;
-    // Deletes all notifications from the notifications panel.
-    dismissAll: ServiceFunction<object, T, object>;
-  };
   homeassistant: {
     // Saves the persistent states immediately. Maintains the normal periodic saving interval.
     savePersistentStates: ServiceFunction<object, T, object>;
@@ -80,6 +54,32 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
     >;
     // Reload all YAML configuration that can be reloaded without restarting Home Assistant.
     reloadAll: ServiceFunction<object, T, object>;
+  };
+  persistentNotification: {
+    // Shows a notification on the notifications panel.
+    create: ServiceFunction<
+      object,
+      T,
+      {
+        // Message body of the notification. @example Please check your configuration.yaml.
+        message: string;
+        // Optional title of the notification. @example Test notification
+        title?: string;
+        // ID of the notification. This new notification will overwrite an existing notification with the same ID. @example 1234
+        notification_id?: string;
+      }
+    >;
+    // Deletes a notification from the notifications panel.
+    dismiss: ServiceFunction<
+      object,
+      T,
+      {
+        // ID of the notification to be deleted. @example 1234
+        notification_id: string;
+      }
+    >;
+    // Deletes all notifications from the notifications panel.
+    dismissAll: ServiceFunction<object, T, object>;
   };
   systemLog: {
     // Deletes all log entries.
@@ -452,7 +452,7 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       object,
       T,
       {
-        // The players which will be synced with the playback specified in `target`. @example - media_player.multiroom_player2 - media_player.multiroom_player3
+        // The players which will be synced with the playback specified in 'Targets'. @example - media_player.multiroom_player2 - media_player.multiroom_player3
         group_members: string[];
       }
     >;
@@ -927,29 +927,55 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       {
         // The entity ID of the new scene. @example all_lights
         scene_id: string;
-        // List of entities and their target state. If your entities are already in the target state right now, use `snapshot_entities` instead. @example light.tv_back_light: 'on' light.ceiling:   state: 'on'   brightness: 200
+        // List of entities and their target state. If your entities are already in the target state right now, use 'Entities snapshot' instead. @example light.tv_back_light: 'on' light.ceiling:   state: 'on'   brightness: 200
         entities?: object;
-        // List of entities to be included in the snapshot. By taking a snapshot, you record the current state of those entities. If you do not want to use the current state of all your entities for this scene, you can combine the `snapshot_entities` with `entities`. @example - light.ceiling - light.kitchen
+        // List of entities to be included in the snapshot. By taking a snapshot, you record the current state of those entities. If you do not want to use the current state of all your entities for this scene, you can combine 'Entities snapshot' with 'Entity states'. @example - light.ceiling - light.kitchen
         snapshot_entities?: string;
       }
     >;
     // Deletes a dynamically created scene.
     delete: ServiceFunction<object, T, object>;
   };
-  logbook: {
-    // Creates a custom entry in the logbook.
-    log: ServiceFunction<
+  camera: {
+    // Enables the motion detection.
+    enableMotionDetection: ServiceFunction<object, T, object>;
+    // Disables the motion detection.
+    disableMotionDetection: ServiceFunction<object, T, object>;
+    // Turns off the camera.
+    turnOff: ServiceFunction<object, T, object>;
+    // Turns on the camera.
+    turnOn: ServiceFunction<object, T, object>;
+    // Takes a snapshot from a camera.
+    snapshot: ServiceFunction<
       object,
       T,
       {
-        // Custom name for an entity, can be referenced using an `entity_id`. @example Kitchen
-        name: string;
-        // Message of the logbook entry. @example is being used
-        message: string;
-        // Entity to reference in the logbook entry.
-        entity_id?: string;
-        // Determines which icon is used in the logbook entry. The icon illustrates the integration domain related to this logbook entry. @example light
-        domain?: string;
+        // Full path to filename. @example /tmp/snapshot_{{ entity_id.name }}.jpg
+        filename: string;
+      }
+    >;
+    // Plays the camera stream on a supported media player.
+    playStream: ServiceFunction<
+      object,
+      T,
+      {
+        // Media players to stream to.
+        media_player: string;
+        // Stream format supported by the media player.
+        format?: "hls";
+      }
+    >;
+    // Creates a recording of a live camera feed.
+    record: ServiceFunction<
+      object,
+      T,
+      {
+        // Full path to filename. Must be mp4. @example /tmp/snapshot_{{ entity_id.name }}.mp4
+        filename: string;
+        // Planned duration of the recording. The actual duration may vary. @constraints  number: min: 1, max: 3600, unit_of_measurement: seconds
+        duration?: number;
+        // Planned lookback period to include in the recording (in addition to the duration). Only available if there is currently an active HLS stream. The actual length of the lookback period may vary. @constraints  number: min: 0, max: 300, unit_of_measurement: seconds
+        lookback?: number;
       }
     >;
   };
@@ -1015,6 +1041,23 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
     // Starts a script if it isn't running, stops it otherwise.
     toggle: ServiceFunction<object, T, object>;
   };
+  logbook: {
+    // Creates a custom entry in the logbook.
+    log: ServiceFunction<
+      object,
+      T,
+      {
+        // Custom name for an entity, can be referenced using an `entity_id`. @example Kitchen
+        name: string;
+        // Message of the logbook entry. @example is being used
+        message: string;
+        // Entity to reference in the logbook entry.
+        entity_id?: string;
+        // Determines which icon is used in the logbook entry. The icon illustrates the integration domain related to this logbook entry. @example light
+        domain?: string;
+      }
+    >;
+  };
   inputNumber: {
     // Reloads helpers from the YAML-configuration.
     reload: ServiceFunction<object, T, object>;
@@ -1036,48 +1079,15 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
     // Reloads zones from the YAML-configuration.
     reload: ServiceFunction<object, T, object>;
   };
-  camera: {
-    // Enables the motion detection.
-    enableMotionDetection: ServiceFunction<object, T, object>;
-    // Disables the motion detection.
-    disableMotionDetection: ServiceFunction<object, T, object>;
-    // Turns off the camera.
-    turnOff: ServiceFunction<object, T, object>;
-    // Turns on the camera.
+  inputBoolean: {
+    // Reloads helpers from the YAML-configuration.
+    reload: ServiceFunction<object, T, object>;
+    // Turns on the helper.
     turnOn: ServiceFunction<object, T, object>;
-    // Takes a snapshot from a camera.
-    snapshot: ServiceFunction<
-      object,
-      T,
-      {
-        // Full path to filename. @example /tmp/snapshot_{{ entity_id.name }}.jpg
-        filename: string;
-      }
-    >;
-    // Plays the camera stream on a supported media player.
-    playStream: ServiceFunction<
-      object,
-      T,
-      {
-        // Media players to stream to.
-        media_player: string;
-        // Stream format supported by the media player.
-        format?: "hls";
-      }
-    >;
-    // Creates a recording of a live camera feed.
-    record: ServiceFunction<
-      object,
-      T,
-      {
-        // Full path to filename. Must be mp4. @example /tmp/snapshot_{{ entity_id.name }}.mp4
-        filename: string;
-        // Planned duration of the recording. The actual duration may vary. @constraints  number: min: 1, max: 3600, unit_of_measurement: seconds
-        duration?: number;
-        // Planned lookback period to include in the recording (in addition to the duration). Only available if there is currently an active HLS stream. The actual length of the lookback period may vary. @constraints  number: min: 0, max: 300, unit_of_measurement: seconds
-        lookback?: number;
-      }
-    >;
+    // Turns off the helper.
+    turnOff: ServiceFunction<object, T, object>;
+    // Toggles the helper on/off.
+    toggle: ServiceFunction<object, T, object>;
   };
   timer: {
     // Reloads timers from the YAML-configuration.
@@ -1106,16 +1116,6 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
         duration: string;
       }
     >;
-  };
-  inputBoolean: {
-    // Reloads helpers from the YAML-configuration.
-    reload: ServiceFunction<object, T, object>;
-    // Turns on the helper.
-    turnOn: ServiceFunction<object, T, object>;
-    // Turns off the helper.
-    turnOff: ServiceFunction<object, T, object>;
-    // Toggles the helper on/off.
-    toggle: ServiceFunction<object, T, object>;
   };
   lock: {
     // Unlocks a lock.
@@ -1146,23 +1146,12 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       }
     >;
   };
-  valve: {
-    // Opens a valve.
-    openValve: ServiceFunction<object, T, object>;
-    // Closes a valve.
-    closeValve: ServiceFunction<object, T, object>;
-    // Moves a valve to a specific position.
-    setValvePosition: ServiceFunction<
-      object,
-      T,
-      {
-        // Target position. @constraints  number: min: 0, max: 100, unit_of_measurement: %
-        position: number;
-      }
-    >;
-    // Stops the valve movement.
-    stopValve: ServiceFunction<object, T, object>;
-    // Toggles a valve open/closed.
+  switch: {
+    // Turns a switch off.
+    turnOff: ServiceFunction<object, T, object>;
+    // Turns a switch on.
+    turnOn: ServiceFunction<object, T, object>;
+    // Toggles a switch on/off.
     toggle: ServiceFunction<object, T, object>;
   };
   cover: {
@@ -1201,14 +1190,6 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
     // Toggles a cover tilt open/closed.
     toggleCoverTilt: ServiceFunction<object, T, object>;
   };
-  switch: {
-    // Turns a switch off.
-    turnOff: ServiceFunction<object, T, object>;
-    // Turns a switch on.
-    turnOn: ServiceFunction<object, T, object>;
-    // Toggles a switch on/off.
-    toggle: ServiceFunction<object, T, object>;
-  };
   conversation: {
     // Launches a conversation from a transcribed text.
     process: ServiceFunction<
@@ -1234,6 +1215,59 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
         language?: string;
         // Conversation agent to reload. @example homeassistant
         agent_id?: string;
+      }
+    >;
+  };
+  valve: {
+    // Opens a valve.
+    openValve: ServiceFunction<object, T, object>;
+    // Closes a valve.
+    closeValve: ServiceFunction<object, T, object>;
+    // Moves a valve to a specific position.
+    setValvePosition: ServiceFunction<
+      object,
+      T,
+      {
+        // Target position. @constraints  number: min: 0, max: 100, unit_of_measurement: %
+        position: number;
+      }
+    >;
+    // Stops the valve movement.
+    stopValve: ServiceFunction<object, T, object>;
+    // Toggles a valve open/closed.
+    toggle: ServiceFunction<object, T, object>;
+  };
+  vacuum: {
+    // Starts or resumes the cleaning task.
+    start: ServiceFunction<object, T, object>;
+    // Pauses the cleaning task.
+    pause: ServiceFunction<object, T, object>;
+    // Tells the vacuum cleaner to return to its dock.
+    returnToBase: ServiceFunction<object, T, object>;
+    // Tells the vacuum cleaner to do a spot clean-up.
+    cleanSpot: ServiceFunction<object, T, object>;
+    // Locates the vacuum cleaner robot.
+    locate: ServiceFunction<object, T, object>;
+    // Stops the current cleaning task.
+    stop: ServiceFunction<object, T, object>;
+    // Sets the fan speed of the vacuum cleaner.
+    setFanSpeed: ServiceFunction<
+      object,
+      T,
+      {
+        // Fan speed. The value depends on the integration. Some integrations have speed steps, like 'medium'. Some use a percentage, between 0 and 100. @example low
+        fan_speed: string;
+      }
+    >;
+    // Sends a command to the vacuum cleaner.
+    sendCommand: ServiceFunction<
+      object,
+      T,
+      {
+        // Command to execute. The commands are integration-specific. @example set_dnd_timer
+        command: string;
+        // Parameters for the command. The parameters are integration-specific. @example { 'key': 'value' }
+        params?: object;
       }
     >;
   };
@@ -1302,39 +1336,17 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       }
     >;
   };
-  vacuum: {
-    // Starts or resumes the cleaning task.
-    start: ServiceFunction<object, T, object>;
-    // Pauses the cleaning task.
-    pause: ServiceFunction<object, T, object>;
-    // Tells the vacuum cleaner to return to its dock.
-    returnToBase: ServiceFunction<object, T, object>;
-    // Tells the vacuum cleaner to do a spot clean-up.
-    cleanSpot: ServiceFunction<object, T, object>;
-    // Locates the vacuum cleaner robot.
-    locate: ServiceFunction<object, T, object>;
-    // Stops the current cleaning task.
-    stop: ServiceFunction<object, T, object>;
-    // Sets the fan speed of the vacuum cleaner.
-    setFanSpeed: ServiceFunction<
-      object,
-      T,
-      {
-        // Fan speed. The value depends on the integration. Some integrations have speed steps, like 'medium'. Some use a percentage, between 0 and 100. @example low
-        fan_speed: string;
-      }
-    >;
-    // Sends a command to the vacuum cleaner.
-    sendCommand: ServiceFunction<
-      object,
-      T,
-      {
-        // Command to execute. The commands are integration-specific. @example set_dnd_timer
-        command: string;
-        // Parameters for the command. The parameters are integration-specific. @example { 'key': 'value' }
-        params?: object;
-      }
-    >;
+  schedule: {
+    // Reloads schedules from the YAML-configuration.
+    reload: ServiceFunction<object, T, object>;
+  };
+  commandLine: {
+    // Reloads command line configuration from the YAML-configuration.
+    reload: ServiceFunction<object, T, object>;
+  };
+  template: {
+    // Reloads template entities from the YAML-configuration.
+    reload: ServiceFunction<object, T, object>;
   };
   reolink: {
     // Plays a ringtone on a Reolink Chime.
@@ -1368,46 +1380,18 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       }
     >;
   };
-  mediaExtractor: {
-    // Extract media URL from a service.
-    extractMediaUrl: ServiceFunction<
+  cast: {
+    // Shows a dashboard view on a Chromecast device.
+    showLovelaceView: ServiceFunction<
       object,
       T,
       {
-        // URL where the media can be found. @example https://www.youtube.com/watch?v=dQw4w9WgXcQ
-        url: string;
-        // Youtube-dl query to select the quality of the result. @example best
-        format_query?: string;
-      }
-    >;
-    // Downloads file from given URL.
-    playMedia: ServiceFunction<
-      object,
-      T,
-      {
-        // The ID of the content to play. Platform dependent. @example https://soundcloud.com/bruttoband/brutto-11
-        media_content_id: string | number;
-        // The type of the content to play. Must be one of MUSIC, TVSHOW, VIDEO, EPISODE, CHANNEL or PLAYLIST MUSIC.
-        media_content_type: "CHANNEL" | "EPISODE" | "PLAYLIST MUSIC" | "MUSIC" | "TVSHOW" | "VIDEO";
-      }
-    >;
-  };
-  restCommand: {
-    //
-    assistantRelay: ServiceFunction<object, T, object>;
-    // Reloads RESTful commands from the YAML-configuration.
-    reload: ServiceFunction<object, T, object>;
-  };
-  inputText: {
-    // Reloads helpers from the YAML-configuration.
-    reload: ServiceFunction<object, T, object>;
-    // Sets the value.
-    setValue: ServiceFunction<
-      object,
-      T,
-      {
-        // The target value. @example This is an example text
-        value: string;
+        // Media player entity to show the dashboard view on.
+        entity_id: string;
+        // The URL path of the dashboard to show. @example lovelace-cast
+        dashboard_path: string;
+        // The URL path of the dashboard view to show. @example downstairs
+        view_path?: string;
       }
     >;
   };
@@ -1447,32 +1431,61 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       }
     >;
   };
-  template: {
-    // Reloads template entities from the YAML-configuration.
+  restCommand: {
+    //
+    assistantRelay: ServiceFunction<object, T, object>;
+    // Reloads RESTful commands from the YAML-configuration.
     reload: ServiceFunction<object, T, object>;
   };
-  cast: {
-    // Shows a dashboard view on a Chromecast device.
-    showLovelaceView: ServiceFunction<
+  mediaExtractor: {
+    // Extract media URL from a service.
+    extractMediaUrl: ServiceFunction<
       object,
       T,
       {
-        // Media player entity to show the dashboard view on.
-        entity_id: string;
-        // The URL path of the dashboard to show. @example lovelace-cast
-        dashboard_path: string;
-        // The URL path of the dashboard view to show. @example downstairs
-        view_path?: string;
+        // URL where the media can be found. @example https://www.youtube.com/watch?v=dQw4w9WgXcQ
+        url: string;
+        // Youtube-dl query to select the quality of the result. @example best
+        format_query?: string;
+      }
+    >;
+    // Downloads file from given URL.
+    playMedia: ServiceFunction<
+      object,
+      T,
+      {
+        // The ID of the content to play. Platform dependent. @example https://soundcloud.com/bruttoband/brutto-11
+        media_content_id: string | number;
+        // The type of the content to play. Must be one of MUSIC, TVSHOW, VIDEO, EPISODE, CHANNEL or PLAYLIST MUSIC.
+        media_content_type: "CHANNEL" | "EPISODE" | "PLAYLIST MUSIC" | "MUSIC" | "TVSHOW" | "VIDEO";
       }
     >;
   };
-  schedule: {
-    // Reloads schedules from the YAML-configuration.
+  inputText: {
+    // Reloads helpers from the YAML-configuration.
     reload: ServiceFunction<object, T, object>;
+    // Sets the value.
+    setValue: ServiceFunction<
+      object,
+      T,
+      {
+        // The target value. @example This is an example text
+        value: string;
+      }
+    >;
   };
-  commandLine: {
-    // Reloads command line configuration from the YAML-configuration.
-    reload: ServiceFunction<object, T, object>;
+  assistSatellite: {
+    // Let the satellite announce a message.
+    announce: ServiceFunction<
+      object,
+      T,
+      {
+        // The message to announce. @example Time to wake up!
+        message?: string;
+        // The media ID to announce instead of using text-to-speech.
+        media_id?: string;
+      }
+    >;
   };
   lawnMower: {
     // Starts the mowing task.
@@ -1552,30 +1565,6 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
     // Logs all the current asyncio tasks.
     logCurrentTasks: ServiceFunction<object, T, object>;
   };
-  assistSatellite: {
-    // Let the satellite announce a message.
-    announce: ServiceFunction<
-      object,
-      T,
-      {
-        // The message to announce. @example Time to wake up!
-        message?: string;
-        // The media ID to announce instead of using text-to-speech.
-        media_id?: string;
-      }
-    >;
-  };
-  number: {
-    // Sets the value of a number.
-    setValue: ServiceFunction<
-      object,
-      T,
-      {
-        // The target value to set. @example 42
-        value?: string;
-      }
-    >;
-  };
   select: {
     // Selects the first option.
     selectFirst: ServiceFunction<object, T, object>;
@@ -1606,6 +1595,17 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       {
         // If the option should cycle from the first to the last.
         cycle?: boolean;
+      }
+    >;
+  };
+  number: {
+    // Sets the value of a number.
+    setValue: ServiceFunction<
+      object,
+      T,
+      {
+        // The target value to set. @example 42
+        value?: string;
       }
     >;
   };
@@ -1666,17 +1666,6 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
         device?: string;
         // The single command or the list of commands to be deleted. @example Mute
         command: object;
-      }
-    >;
-  };
-  weather: {
-    // Get weather forecasts.
-    getForecasts: ServiceFunction<
-      object,
-      T,
-      {
-        // Forecast type: daily, hourly or twice daily.
-        type: "daily" | "hourly" | "twice_daily";
       }
     >;
   };
@@ -1849,79 +1838,6 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       }
     >;
   };
-  text: {
-    // Sets the value.
-    setValue: ServiceFunction<
-      object,
-      T,
-      {
-        // Enter your text. @example Hello world!
-        value: string;
-      }
-    >;
-  };
-  siren: {
-    // Turns the siren on.
-    turnOn: ServiceFunction<
-      object,
-      T,
-      {
-        // The tone to emit. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration. @example fire
-        tone?: string;
-        // The volume. 0 is inaudible, 1 is the maximum volume. Must be supported by the integration. @example 0.5 @constraints  number: min: 0, max: 1, step: 0.05
-        volume_level?: number;
-        // Number of seconds the sound is played. Must be supported by the integration. @example 15
-        duration?: string;
-      }
-    >;
-    // Turns the siren off.
-    turnOff: ServiceFunction<object, T, object>;
-    // Toggles the siren on/off.
-    toggle: ServiceFunction<object, T, object>;
-  };
-  calendar: {
-    // Adds a new calendar event.
-    createEvent: ServiceFunction<
-      object,
-      T,
-      {
-        // Defines the short summary or subject for the event. @example Department Party
-        summary: string;
-        // A more complete description of the event than the one provided by the summary. @example Meeting to provide technical review for 'Phoenix' design.
-        description?: string;
-        // The date and time the event should start. @example 2022-03-22 20:00:00
-        start_date_time?: string;
-        // The date and time the event should end. @example 2022-03-22 22:00:00
-        end_date_time?: string;
-        // The date the all-day event should start. @example 2022-03-22
-        start_date?: string;
-        // The date the all-day event should end (exclusive). @example 2022-03-23
-        end_date?: string;
-        // Days or weeks that you want to create the event in. @example {'days': 2} or {'weeks': 2}
-        in?: object;
-        // The location of the event. @example Conference Room - F123, Bldg. 002
-        location?: string;
-      }
-    >;
-    // Get events on a calendar within a time range.
-    getEvents: ServiceFunction<
-      object,
-      T,
-      {
-        // Returns active events after this time (exclusive). When not set, defaults to now. @example 2022-03-22 20:00:00
-        start_date_time?: string;
-        // Returns active events before this time (exclusive). Cannot be used with Duration. @example 2022-03-22 22:00:00
-        end_date_time?: string;
-        // Returns active events from Start time for the specified duration.
-        duration?: {
-          hours?: number;
-          days?: number;
-          minutes?: number;
-          seconds?: number;
-        };
-      }
-    >;
-  };
   fan: {
     // Turns fan on.
     turnOn: ServiceFunction<
@@ -1990,6 +1906,90 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
       {
         // Preset fan mode. @example auto
         preset_mode: string;
+      }
+    >;
+  };
+  siren: {
+    // Turns the siren on.
+    turnOn: ServiceFunction<
+      object,
+      T,
+      {
+        // The tone to emit. When `available_tones` property is a map, either the key or the value can be used. Must be supported by the integration. @example fire
+        tone?: string;
+        // The volume. 0 is inaudible, 1 is the maximum volume. Must be supported by the integration. @example 0.5 @constraints  number: min: 0, max: 1, step: 0.05
+        volume_level?: number;
+        // Number of seconds the sound is played. Must be supported by the integration. @example 15
+        duration?: string;
+      }
+    >;
+    // Turns the siren off.
+    turnOff: ServiceFunction<object, T, object>;
+    // Toggles the siren on/off.
+    toggle: ServiceFunction<object, T, object>;
+  };
+  calendar: {
+    // Adds a new calendar event.
+    createEvent: ServiceFunction<
+      object,
+      T,
+      {
+        // Defines the short summary or subject for the event. @example Department Party
+        summary: string;
+        // A more complete description of the event than the one provided by the summary. @example Meeting to provide technical review for 'Phoenix' design.
+        description?: string;
+        // The date and time the event should start. @example 2022-03-22 20:00:00
+        start_date_time?: string;
+        // The date and time the event should end. @example 2022-03-22 22:00:00
+        end_date_time?: string;
+        // The date the all-day event should start. @example 2022-03-22
+        start_date?: string;
+        // The date the all-day event should end (exclusive). @example 2022-03-23
+        end_date?: string;
+        // Days or weeks that you want to create the event in. @example {'days': 2} or {'weeks': 2}
+        in?: object;
+        // The location of the event. @example Conference Room - F123, Bldg. 002
+        location?: string;
+      }
+    >;
+    // Get events on a calendar within a time range.
+    getEvents: ServiceFunction<
+      object,
+      T,
+      {
+        // Returns active events after this time (exclusive). When not set, defaults to now. @example 2022-03-22 20:00:00
+        start_date_time?: string;
+        // Returns active events before this time (exclusive). Cannot be used with Duration. @example 2022-03-22 22:00:00
+        end_date_time?: string;
+        // Returns active events from Start time for the specified duration.
+        duration?: {
+          hours?: number;
+          days?: number;
+          minutes?: number;
+          seconds?: number;
+        };
+      }
+    >;
+  };
+  weather: {
+    // Get weather forecasts.
+    getForecasts: ServiceFunction<
+      object,
+      T,
+      {
+        // Forecast type: daily, hourly or twice daily.
+        type: "daily" | "hourly" | "twice_daily";
+      }
+    >;
+  };
+  text: {
+    // Sets the value.
+    setValue: ServiceFunction<
+      object,
+      T,
+      {
+        // Enter your text. @example Hello world!
+        value: string;
       }
     >;
   };
@@ -2066,5 +2066,172 @@ export interface DefaultServices<T extends ServiceFunctionTypes = "target"> {
     >;
     // Reloads the automation configuration.
     reload: ServiceFunction<object, T, object>;
+  };
+  zha: {
+    // Allows nodes to join the Zigbee network.
+    permit: ServiceFunction<
+      object,
+      T,
+      {
+        // Time to permit joins. @constraints  number: min: 0, max: 254, unit_of_measurement: seconds
+        duration?: number;
+        // IEEE address of the node permitting new joins. @example 00:0d:6f:00:05:7d:2d:34
+        ieee?: string;
+        // IEEE address of the joining device (must be used with the install code). @example 00:0a:bf:00:01:10:23:35
+        source_ieee?: string;
+        // Install code of the joining device (must be used with the source_ieee). @example 1234-5678-1234-5678-AABB-CCDD-AABB-CCDD-EEFF
+        install_code?: string;
+        // Value of the QR install code (different between vendors). @example Z:000D6FFFFED4163B$I:52797BF4A5084DAA8E1712B61741CA024051
+        qr_code?: string;
+      }
+    >;
+    // Removes a node from the Zigbee network.
+    remove: ServiceFunction<
+      object,
+      T,
+      {
+        // IEEE address of the node to remove. @example 00:0d:6f:00:05:7d:2d:34
+        ieee: string;
+      }
+    >;
+    // Sets an attribute value for the specified cluster on the specified entity.
+    setZigbeeClusterAttribute: ServiceFunction<
+      object,
+      T,
+      {
+        // IEEE address for the device. @example 00:0d:6f:00:05:7d:2d:34
+        ieee: string;
+        // Endpoint ID for the cluster. @constraints  number: min: 1, max: 65535, mode: box
+        endpoint_id: number;
+        // ZCL cluster to retrieve attributes for. @constraints  number: min: 1, max: 65535
+        cluster_id: number;
+        // Type of the cluster.
+        cluster_type?: "in" | "out";
+        // ID of the attribute to set. @constraints  number: min: 1, max: 65535
+        attribute: number;
+        // Value to write to the attribute. @example 1
+        value: string;
+        // Manufacturer code. Use a value of '-1' to force no code to be set. @example 252
+        manufacturer?: string;
+      }
+    >;
+    // Issues a command on the specified cluster on the specified entity.
+    issueZigbeeClusterCommand: ServiceFunction<
+      object,
+      T,
+      {
+        // IEEE address for the device. @example 00:0d:6f:00:05:7d:2d:34
+        ieee: string;
+        // Endpoint ID for the cluster. @constraints  number: min: 1, max: 65535
+        endpoint_id: number;
+        // ZCL cluster to retrieve attributes for. @constraints  number: min: 1, max: 65535
+        cluster_id: number;
+        // Type of the cluster.
+        cluster_type?: "in" | "out";
+        // ID of the command to execute. @constraints  number: min: 1, max: 65535
+        command: number;
+        // Type of the command to execute.
+        command_type: "client" | "server";
+        // Arguments to pass to the command. @example [arg1, arg2, argN]
+        args?: object;
+        // Parameters to pass to the command.
+        params?: object;
+        // Manufacturer code. Use a value of '-1' to force no code to be set. @example 252
+        manufacturer?: string;
+      }
+    >;
+    // Issue command on the specified cluster on the specified group.
+    issueZigbeeGroupCommand: ServiceFunction<
+      object,
+      T,
+      {
+        // Hexadecimal address of the group. @example 546
+        group: string;
+        // ZCL cluster to send command to. @constraints  number: min: 1, max: 65535
+        cluster_id: number;
+        // Type of the cluster.
+        cluster_type?: "in" | "out";
+        // ID of the command to execute. @constraints  number: min: 1, max: 65535
+        command: number;
+        // Arguments to pass to the command. @example [arg1, arg2, argN]
+        args?: object;
+        // Manufacturer code. Use a value of '-1' to force no code to be set. @example 252
+        manufacturer?: string;
+      }
+    >;
+    // This action uses the WD capabilities to emit a quick audible/visible pulse called a 'squawk'. The squawk command has no effect if the WD is currently active (warning in progress).
+    warningDeviceSquawk: ServiceFunction<
+      object,
+      T,
+      {
+        // IEEE address for the device. @example 00:0d:6f:00:05:7d:2d:34
+        ieee: string;
+        // The Squawk Mode field is used as a 4-bit enumeration, and can have one of the values shown in Table 8-24 of the ZCL spec - Squawk Mode Field. The exact operation of each mode (how the WD “squawks”) is implementation specific. @constraints  number: min: 0, max: 1, mode: box
+        mode?: number;
+        // The strobe field is used as a Boolean, and determines if the visual indication is also required in addition to the audible squawk, as shown in Table 8-25 of the ZCL spec - Strobe Bit. @constraints  number: min: 0, max: 1, mode: box
+        strobe?: number;
+        // The squawk level field is used as a 2-bit enumeration, and determines the intensity of audible squawk sound as shown in Table 8-26 of the ZCL spec - Squawk Level Field Values. @constraints  number: min: 0, max: 3, mode: box
+        level?: number;
+      }
+    >;
+    // This action starts the operation of the warning device. The warning device alerts the surrounding area by audible (siren) and visual (strobe) signals.
+    warningDeviceWarn: ServiceFunction<
+      object,
+      T,
+      {
+        // IEEE address for the device. @example 00:0d:6f:00:05:7d:2d:34
+        ieee: string;
+        // The Warning Mode field is used as a 4-bit enumeration, can have one of the values 0-6 defined below in table 8-20 of the ZCL spec. The exact behavior of the warning device in each mode is according to the relevant security standards. @constraints  number: min: 0, max: 6, mode: box
+        mode?: number;
+        // The Strobe field is used as a 2-bit enumeration, and determines if the visual indication is required in addition to the audible siren, as indicated in Table 8-21 of the ZCL spec. '0' means no strobe, '1' means strobe. If the strobe field is “1” and the Warning Mode is “0” (“Stop”), then only the strobe is activated. @constraints  number: min: 0, max: 1, mode: box
+        strobe?: number;
+        // The Siren Level field is used as a 2-bit enumeration, and indicates the intensity of audible squawk sound as shown in Table 8-22 of the ZCL spec. @constraints  number: min: 0, max: 3, mode: box
+        level?: number;
+        // Requested duration of warning, in seconds (16 bit). If both Strobe and Warning Mode are '0' this field is ignored. @constraints  number: min: 0, max: 65535, unit_of_measurement: seconds
+        duration?: number;
+        // Indicates the length of the flash cycle. This allows you to vary the flash duration for different alarm types (e.g., fire, police, burglar). The valid range is 0-100 in increments of 10. All other values must be rounded to the nearest valid value. Strobe calculates a duty cycle over a duration of one second. The ON state must precede the OFF state. For example, if the Strobe Duty Cycle field specifies “40,”, then the strobe flashes ON for 4/10ths of a second and then turns OFF for 6/10ths of a second. @constraints  number: min: 0, max: 100, step: 10
+        duty_cycle?: number;
+        // Indicates the intensity of the strobe as shown in Table 8-23 of the ZCL spec. This attribute is designed to vary the output of the strobe (i.e., brightness) and not its frequency, which is detailed in section 8.4.2.3.1.6 of the ZCL spec. @constraints  number: min: 0, max: 3, mode: box
+        intensity?: number;
+      }
+    >;
+    // Sets a user code on a lock.
+    setLockUserCode: ServiceFunction<
+      object,
+      T,
+      {
+        // Code slot to set the code in. @example 1
+        code_slot: string;
+        // Code to set. @example 1234
+        user_code: string;
+      }
+    >;
+    // Enables a user code on a lock.
+    enableLockUserCode: ServiceFunction<
+      object,
+      T,
+      {
+        // Code slot to enable. @example 1
+        code_slot: string;
+      }
+    >;
+    // Disables a user code on a lock.
+    disableLockUserCode: ServiceFunction<
+      object,
+      T,
+      {
+        // Code slot to disable. @example 1
+        code_slot: string;
+      }
+    >;
+    // Clears a user code from a lock.
+    clearLockUserCode: ServiceFunction<
+      object,
+      T,
+      {
+        // Code slot to clear code from. @example 1
+        code_slot: string;
+      }
+    >;
   };
 }

--- a/packages/core/src/utils/computeDomainTitle.ts
+++ b/packages/core/src/utils/computeDomainTitle.ts
@@ -45,6 +45,7 @@ export const computeDomainTitle = <E extends EntityName | "unknown">(entityId: E
     case "google":
     case "reolink":
     case "notify":
+    case 'zha':
     case "vacuum":
       return startCase(lowerCase(domain));
     default: {

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -14,9 +14,9 @@
     }
   },
   "rootDir": "./src",
-  "include": ["src", "scripts", "bin", "mocks", "./src/.d.ts", "../../.d.ts"],
+  "include": ["src", "scripts", "bin", "mocks", "./src/.d.ts", "../../.d.ts", "./vite-env.d.ts"],
   "exclude": [
-    "node_modules"
+    "node_modules",
   ],
   "references": [{ "path": "./tsconfig.node.json" }]
 }

--- a/packages/core/vite-env.d.ts
+++ b/packages/core/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -50,7 +50,7 @@ export default defineConfig(configEnv => {
             'src/**/**/*.{ts,tsx}',
             'src/**/locales/**/*.json',
           ], {
-            ignore: ['**/*stories.ts', '**/*stories.tsx', "**/*.test.{ts,tsx}"]
+            ignore: ['**/*stories.ts', '**/*stories.tsx', "**/*.test.{ts,tsx}", "**/*.code.{ts,tsx}"]
           }).map(file => {
             return [
             // The name of the entry point

--- a/stories/3.responsive.stories.tsx
+++ b/stories/3.responsive.stories.tsx
@@ -125,7 +125,7 @@ export type UseBreakpoint = StoryObj<typeof Empty>;
 export const UseBreakpoint: Story = {
   render: Empty,
   parameters: {
-    redirectTo: '/?path=/docs/components-hooks-usebreakpoint--docs',
+    redirectTo: '/docs/components-hooks-usebreakpoint--docs',
   }
 };
 

--- a/stories/3b.responsiveBreakpoints.stories.tsx
+++ b/stories/3b.responsiveBreakpoints.stories.tsx
@@ -1,5 +1,6 @@
 import { Story, Source } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
+import { redirectToStory } from '../.storybook/redirect';
 import breakpointExample from './codeExamples/breakpointExample.code?raw';
 
 export default {
@@ -17,7 +18,10 @@ export default {
       <Source dark code={breakpointExample} />
       <p>The values provided above are the defaults, they should range from smallest to largest and they represent the screen width not the container size.</p>
       <p>If you screen size is 1600px wide, by default the `md` breakpoint will be active, and all cards with an `md` prop provided (or the default values) will be activated and used to determine the size of the cards.</p>
-      <p>Also, with the hook <a href="/?path=/docs/components-hooks-usebreakpoint--docs">useBreakpoint</a>, the .md property will be true.</p>
+      <p>Also, with the hook <a href="" onClick={(e) => {
+          e.preventDefault();
+          redirectToStory('/docs/components-hooks-usebreakpoint--docs');
+        }}>useBreakpoint</a>, the .md property will be true.</p>
       <p>The breakpoint settings above, translate to the following auto generated media queries:</p>
       <Source dark code={`
 export const getBreakpoints = (breakpoints: BreakPoints): Record<BreakPoint, string> => {

--- a/stories/3c.responsiveMqHelper.stories.tsx
+++ b/stories/3c.responsiveMqHelper.stories.tsx
@@ -2,6 +2,7 @@ import { Story, Source } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
 import mqHelperInput from './codeExamples/mqHelperInput.code?raw';
 import mqHelperOutput from './codeExamples/mqHelperOutput.code?raw';
+import { redirectToStory } from '../.storybook/redirect';
 
 export default {
   title: "INTRODUCTION/Responsive Layouts/Media Query Helper",
@@ -19,7 +20,10 @@ export default {
       <p>As you can see with the example above, you provide the breakpoint name in the first param as an array of breakpoints, and the second value will be a CSS string which will be applied with this breakpoint.</p>
       <p>This function is actually quite simple and is designed to be used with styled component libraries, this will actually generate css like this:</p>
       <Source dark code={mqHelperOutput} />
-      <p>See more about the available helper classes <a href="/?path=/docs/introduction-responsive-layouts-css-classes--docs">here</a>.</p>
+      <p>See more about the available helper classes <a href="#" onClick={(e) => {
+        e.preventDefault();
+        redirectToStory('/docs/introduction-responsive-layouts-css-classes--docs');
+      }}>here</a>.</p>
     </>
   },
 } satisfies Meta;

--- a/stories/3d.responsiveClasses.stories.tsx
+++ b/stories/3d.responsiveClasses.stories.tsx
@@ -1,5 +1,6 @@
 import { Story, Source } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
+import { redirectToStory } from '../.storybook/redirect';
 
 export default {
   title: "INTRODUCTION/Responsive Layouts/CSS Classes",
@@ -13,7 +14,10 @@ export default {
     hidePrimary: true,
     hideComponentProps: true,
     afterPrimary: <>
-      <p>For every available breakpoint (see <a href="/?path=/docs/introduction-responsive-layouts-breakpoints--docs">breakpoints</a> for more info) a css class is available to use to conditionally style your components.</p>
+      <p>For every available breakpoint (see <a href="#" onClick={(e) => {
+              e.preventDefault();
+              redirectToStory('/docs/introduction-responsive-layouts-breakpoints--docs');
+            }}>breakpoints</a> for more info) a css class is available to use to conditionally style your components.</p>
       <p>When a breakpoint is active, the current breakpoint class will be added to the body of the document, for example if we&quot;re in the range for a `lg` breakpoint, the following will apply to the body:</p>
       <Source dark code={`<body class="bp-lg">...</body>`} />
 

--- a/stories/tsconfig.json
+++ b/stories/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": "../tsconfig",
-  "include": ["./*", "../.d.ts", "../vite-env.d.ts"],
+  "include": ["./*", "../.d.ts", "./vite-env.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/stories/vite-env.d.ts
+++ b/stories/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
The animations for the dashboard had a big side effect, where all cards would "animate" their position before rendering, when the desired effect should only be applied when expanding the modal, this fixes this [issue](https://github.com/shannonhochkins/ha-component-kit/issues/179).

Unfortunately, framer motion doesn't allow you to conditionally set the layoutId, and would require a very custom setup to achieve the same result, from feedback from users, they do want simpler animations, quicker ways to navigate and see fields, animations are less on the roadmap for this dashboard right now.

So, for now! This PR introduces a change to REMOVE the scaling modal popup, and now the modal will pop into view from the bottom of the screen

- Modals now loading a lot quicker than before
- Content popping in much quicker
- No layout shift initially, CLS score will be better for private dashboards ;) 
- AreaCard also has this change applied so the popup will just appear on screen now
- Added documentation on how to add this effect back in if need be.