### PR TITLE
Introduce two new hooks

### DIFF
--- a/hass-connect-fake/tsconfig.json
+++ b/hass-connect-fake/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "skipLibCheck": true,
   },
-  "include": ["*", "../.d.ts"],
+  "include": ["*", "../.d.ts", "./vite-env.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/hass-connect-fake/vite-env.d.ts
+++ b/hass-connect-fake/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/components/src/Shared/Column/index.tsx
+++ b/packages/components/src/Shared/Column/index.tsx
@@ -45,7 +45,7 @@ export function Column(props: ColumnProps) {
   return (
     <_Column
       {...props}
-      cssStyles={css`
+      css={css`
         ${props.cssStyles ?? ""}
       `}
       className={`${props.className ?? ""} ${props.fullHeight ? "full-height" : ""} ${props.fullWidth ? "full-width" : ""} ${

--- a/packages/components/src/Shared/Row/index.tsx
+++ b/packages/components/src/Shared/Row/index.tsx
@@ -45,7 +45,7 @@ export function Row(props: RowProps) {
   return (
     <_Row
       {...props}
-      cssStyles={css`
+      css={css`
         ${props.cssStyles ?? ""}
       `}
       className={`${props.className ?? ""} ${props.fullHeight ? "full-height" : ""} ${props.fullWidth ? "full-width" : ""} ${

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -12,6 +12,8 @@ export { useHistory, type HistoryOptions } from "./useHistory";
 export { coordinates, type NumericEntityHistoryState, type coordinatesMinimalResponseCompressedState } from "./useHistory/coordinates";
 export { useSubscribeEntity } from "./useSubscribeEntity";
 export { useLogs, type UseLogOptions } from "./useLogs";
+export { useHaStatus } from "./useHaStatus";
+export { useConfig } from "./useConfig";
 export { useWeather, type UseWeatherOptions } from "./useWeather";
 export { getSupportedForecastTypes, type ForecastType, type ModernForecastType } from "./useWeather/helpers";
 export * from "./useLogs/logbook";

--- a/packages/core/src/hooks/useConfig/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useConfig/examples/basic.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useConfig } from "@hakit/core";
+
+export function Component() {
+  const config = useConfig();
+  return <div>Home Assistant Version: {config?.version}</div>;
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Component />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useConfig/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useConfig/examples/primary.stories.tsx
@@ -1,0 +1,34 @@
+import { HassConnect } from "hass-connect-fake";
+import { Story } from "@storybook/blocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Component } from "./basic.code";
+import { ThemeProvider } from "@hakit/components";
+
+function Primary() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Component />
+    </HassConnect>
+  );
+}
+
+const meta: Meta<typeof Primary> = {
+  component: Primary,
+};
+
+export default meta;
+type Story = StoryObj<typeof Primary>;
+
+export const PrimaryExample: Story = {
+  args: {
+    label: "PrimaryExample",
+  },
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "none",
+      },
+    },
+  },
+};

--- a/packages/core/src/hooks/useConfig/index.ts
+++ b/packages/core/src/hooks/useConfig/index.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState, useMemo } from "react";
+import { subscribeConfig, type HassConfig } from "home-assistant-js-websocket";
+import { useHass } from "@core";
+
+export function useConfig() {
+  const { useStore } = useHass();
+  const connection = useStore((state) => state.connection);
+  const [config, setConfig] = useState<HassConfig | null>(null);
+
+  useEffect(() => {
+    if (!connection) return;
+    // Subscribe to config updates
+    const unsubscribe = subscribeConfig(connection, (newConfig) => {
+      setConfig(newConfig);
+    });
+    // Cleanup function to unsubscribe on unmount
+    return () => {
+      unsubscribe();
+    };
+  }, [connection]); // Only re-run if connection changes
+
+  // Memoize the config to prevent unnecessary re-renders
+  return useMemo(() => config, [config]);
+}

--- a/packages/core/src/hooks/useConfig/useConfigDocs.mdx
+++ b/packages/core/src/hooks/useConfig/useConfigDocs.mdx
@@ -1,0 +1,24 @@
+import { Meta, Source, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useConfig" />
+
+# useConfig()
+###### `useConfig(): HassConfig | null`
+
+A custom React hook to subscribe to the Home Assistant configuration updates, this hook will return a new value every time your instance configuration changes.
+
+This hook will return the configuration object or null if not available yet.
+
+- **Dependencies**: This hook requires you to use it within the `HassConnect` component.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />
+
+

--- a/packages/core/src/hooks/useHaStatus/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useHaStatus/examples/basic.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useHaStatus } from "@hakit/core";
+
+export function Component() {
+  const haStatus = useHaStatus();
+  return <div>Home Assistant Status: {haStatus}</div>;
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Component />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useHaStatus/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useHaStatus/examples/primary.stories.tsx
@@ -1,0 +1,65 @@
+import { HassConnect } from "hass-connect-fake";
+import { Story } from "@storybook/blocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Component } from "./basic.code";
+import { ThemeProvider, FabCard } from "@hakit/components";
+import { useHass } from "@hakit/core";
+import { Column, Row } from '@components';
+
+function ShutDown() {
+  const { useStore } = useHass();
+  const setConfig = useStore((state) => state.setConfig);
+  const config = useStore((state) => state.config);
+  
+  if (!config) return null;
+  // This example code here will not actually trigger the shutdown in a real world scenario
+  // This is just to emulate the behavior of a real world scenario
+  return (
+    <Row gap="1rem">
+      <FabCard cssStyles={`width: 200px`} onClick={() => {
+        setConfig({ ...config, state: "STOPPING" });
+        setTimeout(() => setConfig({ ...config, state: "NOT_RUNNING" }), 1000);
+      }} icon="mdi:power">
+        POWER OFF
+      </FabCard>
+      <FabCard cssStyles={`width: 200px`} onClick={() => {
+        setConfig({ ...config, state: "STARTING" });
+        setTimeout(() => setConfig({ ...config, state: "RUNNING" }), 1000);
+      }} icon="mdi:power">
+        POWER UP
+      </FabCard>
+    </Row>
+  );
+}
+
+function Primary() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Column gap="1rem">
+        <ShutDown />
+        <Component />
+      </Column>
+    </HassConnect>
+  );
+}
+
+const meta: Meta<typeof Primary> = {
+  component: Primary,
+};
+
+export default meta;
+type Story = StoryObj<typeof Primary>;
+
+export const PrimaryExample: Story = {
+  args: {
+    label: "PrimaryExample",
+  },
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "none",
+      },
+    },
+  },
+};

--- a/packages/core/src/hooks/useHaStatus/index.ts
+++ b/packages/core/src/hooks/useHaStatus/index.ts
@@ -1,0 +1,25 @@
+import { useConfig } from "@core";
+import { type HassConfig } from "home-assistant-js-websocket";
+
+/**
+ * useHaStatus - A custom React hook to get the current status of the Home Assistant instance.
+ *
+ * This hook uses the `useHass` hook to access the Home Assistant context and retrieves the configuration state from the store.
+ *
+ * @returns {HassConfig["state"] | "LOADING"} - The current state of the Home Assistant configuration. If the configuration is not available, it returns 'LOADING'.
+ *
+ * Example usage:
+ * ```tsx
+ * import { useHaStatus } from '@core';
+ *
+ * const MyComponent = () => {
+ *   const haStatus = useHaStatus();
+ *
+ *   return <div>Home Assistant Status: {haStatus}</div>;
+ * };
+ * ```
+ */
+export function useHaStatus(): HassConfig["state"] | "LOADING" {
+  const config = useConfig();
+  return config?.state ?? "LOADING";
+}

--- a/packages/core/src/hooks/useHaStatus/useHaStatusDocs.mdx
+++ b/packages/core/src/hooks/useHaStatus/useHaStatusDocs.mdx
@@ -1,0 +1,25 @@
+import { Meta, Source, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useHaStatus" />
+
+# useHaStatus()
+###### `useHaStatus()`
+
+A custom React hook to get the current status of the Home Assistant instance.
+
+This hook uses the `useConfig` hook to access the Home Assistant configuration and retrieves the instance state from the config.
+
+- **Output**: "NOT_RUNNING" | "STARTING" | "RUNNING" | "STOPPING" | "FINAL_WRITE" | "LOADING"
+- **Dependencies**: This hook requires you to use it within the `HassConnect` component.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />
+
+

--- a/packages/core/src/hooks/useHass/examples/useStore.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/useStore.code.tsx
@@ -5,6 +5,7 @@ function UseStoreExample() {
   // there's more available on the store than displayed here, this is just an example
   const entities = useStore((store) => store.entities);
   const connection = useStore((store) => store.connection);
+  // A live update of the configuration
   const config = useStore((store) => store.config);
   const auth = useStore((store) => store.auth);
   console.log("data", {

--- a/packages/core/src/hooks/useHass/useHass.getConfig.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getConfig.mdx
@@ -8,6 +8,8 @@ import getConfigExample from './examples/getConfig.code?raw';
 This will return all information about your configuration of your home assistant instance, this is all typed with typescript
 so you'll have access to what's available on the object with the `HassConfig` type.
 
+> Note: This function will only return the current configuration, it will not subscribe to updates, use the `useConfig` hook to get live updates.
+
 ### Definition
 <Source dark language="ts" code={`await getConfig()`} />
 


### PR DESCRIPTION
NEW - useConfig - A new hook designed to subscribe to the configuration updates from the instance, previously this would only retrieve the configuration from the store, and it would only ever load once.
NEW - useHaStatus - A hook that will return a STRING indicating the current status of your home assistant instance.