### PR TITLE
Warn user when deploying with access token

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,7 @@ name: Bug report
 about: Create a report to help us improve
 title: ''
 labels: ''
-assignees: ''
+assignees: shannonhochkins
 
 ---
 
@@ -24,10 +24,11 @@ A clear and concise description of what you expected to happen.
 If applicable, add screenshots / examples to help explain your problem.
 
 **System Info (please complete the following information):**
- - IDE
+ - IDE (e.g Visual studio code)
  - Browser [e.g. chrome, safari]
  - npm version
  - node version
+ - HA Version
 
 
 **Additional context**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,7 @@ name: Feature request
 about: Suggest an idea for this project
 title: ''
 labels: ''
-assignees: ''
+assignees: shannonhochkins
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+# 5.0.2
+
+### @hakit/components
+- BUGFIX - WeatherCard - When the WeatherCard was used in the dashboard, and enabled in the sidebar, the forecast columns would animate in/out from card to card, this is no longe an issue and solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/189)
+- NEW - Massive improvements to the initial load of the dashboard, it will now loading blazingly fast, and no longer animates into position, now the dashboard will load all cards in place as they should - this solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/179)
+- NEW - Modal animations - previously this would animate and scale in from the card that triggered the action, by default this animation style has changed to a simple slide up/slide down. If you still wish to retain this functionality, you can do this by passing the `layoutId` prop to the card that triggers the modal, and add the same value to the modalProps.id for the card, or manually if you wish there's an example [here](https://shannonhochkins.github.io/ha-component-kit/?path=/story/components-shared-modal--auto-scale-from-source).
+- BUGFIX - MediaPlayerCard - The layout inside the popup for group controls was broken, this has been fixed, the default "slider" for volume controls has been changed to buttons for easier use.
+
+
+### @hakit/core
+- NEW - [useConfig](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-useconfig--docs) - A new hook designed to subscribe to the configuration updates from the instance, previously this would only retrieve the configuration from the store, and it would only ever load once.
+- NEW - useHaStatus - A hook that will return a STRING indicating the current status of your home assistant instance - solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/177)
+- NEW - [useLightTemperature](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-uselighttemperature--docs) - A previously undocumented hook to return the temperature of a light entity, this will return the temperature in Kelvin, if the light doesn't support temperature, it will return undefined, if you want to convert the kelvin value to rgb, there's a `temperature2rgb` method that's also exported from core.
+- NEW - [useLightColor](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-uselightcolor--docs) - A previously undocumented hook to return the color of a light entity, this will return the color in HS format, if the light doesn't support color, it will return undefined, if you want to convert to RGB you can use the `hs2rgb` method that's also exported from core.
+- NEW - [useLightBrightness](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-uselightbrightness--docs) - A previously undocumented hook to return the brightness of a light entity, this will return the brightness in a number format, if the light doesn't support brightness, it will return undefined.
+- BUGFIX - The typescript sync command had an obscure bug where if the field name contained a property of an object, in this case "constructor" the typescript output would be invalid, this solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/194)
+ - NEW - There's a wide range of [helpers](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-helpers--docs) that were previously undocumented, All the relevant/useful helpers have been documented.
+ - NEW - There's a wide range of [constants](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-constants--docs) available which were previously undocumented
+
+### NPM CREATE
+
+- The .nvmrc file will now have the current version of node that was used by the user, previously this was hard coded to version 20 - solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/191)
+
+### Maintenance
+- Huge amount of documentation improvements, a lot more examples and structured documentation.
+- Locales updated for core from latest HA version.
+
+
 # 5.0.1
 
 ### @hakit/components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
 # 5.0.2
 
 ### @hakit/components
-- BUGFIX - WeatherCard - When the WeatherCard was used in the dashboard, and enabled in the sidebar, the forecast columns would animate in/out from card to card, this is no longe an issue and solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/189)
+- BUGFIX - [WeatherCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-weathercard--docs) - When the WeatherCard was used in the dashboard, and enabled in the sidebar, the forecast columns would animate in/out from card to card, this is no longe an issue and solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/189)
 - NEW - Massive improvements to the initial load of the dashboard, it will now loading blazingly fast, and no longer animates into position, now the dashboard will load all cards in place as they should - this solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/179)
 - NEW - Modal animations - previously this would animate and scale in from the card that triggered the action, by default this animation style has changed to a simple slide up/slide down. If you still wish to retain this functionality, you can do this by passing the `layoutId` prop to the card that triggers the modal, and add the same value to the modalProps.id for the card, or manually if you wish there's an example [here](https://shannonhochkins.github.io/ha-component-kit/?path=/story/components-shared-modal--auto-scale-from-source).
-- BUGFIX - MediaPlayerCard - The layout inside the popup for group controls was broken, this has been fixed, the default "slider" for volume controls has been changed to buttons for easier use.
+- BUGFIX - [MediaPlayerCard](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/components-cards-mediaplayercard--docs) - The layout inside the popup for group controls was broken, this has been fixed, the default "slider" for volume controls has been changed to buttons for easier use.
 
 
 ### @hakit/core
 - NEW - [useConfig](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-useconfig--docs) - A new hook designed to subscribe to the configuration updates from the instance, previously this would only retrieve the configuration from the store, and it would only ever load once.
-- NEW - useHaStatus - A hook that will return a STRING indicating the current status of your home assistant instance - solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/177)
+- NEW - [useHaStatus](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-usehastatus--docs) - A hook that will return a STRING indicating the current status of your home assistant instance - solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/177)
 - NEW - [useLightTemperature](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-uselighttemperature--docs) - A previously undocumented hook to return the temperature of a light entity, this will return the temperature in Kelvin, if the light doesn't support temperature, it will return undefined, if you want to convert the kelvin value to rgb, there's a `temperature2rgb` method that's also exported from core.
 - NEW - [useLightColor](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-uselightcolor--docs) - A previously undocumented hook to return the color of a light entity, this will return the color in HS format, if the light doesn't support color, it will return undefined, if you want to convert to RGB you can use the `hs2rgb` method that's also exported from core.
 - NEW - [useLightBrightness](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-hooks-uselightbrightness--docs) - A previously undocumented hook to return the brightness of a light entity, this will return the brightness in a number format, if the light doesn't support brightness, it will return undefined.
@@ -17,7 +17,7 @@
  - NEW - There's a wide range of [helpers](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-helpers--docs) that were previously undocumented, All the relevant/useful helpers have been documented.
  - NEW - There's a wide range of [constants](https://shannonhochkins.github.io/ha-component-kit/?path=/docs/core-constants--docs) available which were previously undocumented
 
-### NPM CREATE
+### NPM CREATE v1.1.10
 
 - The .nvmrc file will now have the current version of node that was used by the user, previously this was hard coded to version 20 - solves [issue](https://github.com/shannonhochkins/ha-component-kit/issues/191)
 

--- a/hass-connect-fake/tsconfig.json
+++ b/hass-connect-fake/tsconfig.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "skipLibCheck": true,
   },
-  "include": ["*", "../.d.ts"],
+  "include": ["*", "../.d.ts", "./vite-env.d.ts"],
   "exclude": ["node_modules"]
 }

--- a/hass-connect-fake/vite-env.d.ts
+++ b/hass-connect-fake/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hakit/components",
   "type": "module",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "private": false,
   "keywords": [
     "react",
@@ -69,7 +69,7 @@
     "@emotion/react": ">=11.x.x",
     "@emotion/styled": ">=11.x",
     "@fullcalendar/react": ">=6.x.x",
-    "@hakit/core": "^5.0.1",
+    "@hakit/core": "^5.0.2",
     "@mui/material": "^6.3.0",
     "@use-gesture/react": ">=10.x",
     "autolinker": ">=4.x",

--- a/packages/components/src/Shared/Column/index.tsx
+++ b/packages/components/src/Shared/Column/index.tsx
@@ -45,7 +45,7 @@ export function Column(props: ColumnProps) {
   return (
     <_Column
       {...props}
-      cssStyles={css`
+      css={css`
         ${props.cssStyles ?? ""}
       `}
       className={`${props.className ?? ""} ${props.fullHeight ? "full-height" : ""} ${props.fullWidth ? "full-width" : ""} ${

--- a/packages/components/src/Shared/Row/index.tsx
+++ b/packages/components/src/Shared/Row/index.tsx
@@ -45,7 +45,7 @@ export function Row(props: RowProps) {
   return (
     <_Row
       {...props}
-      cssStyles={css`
+      css={css`
         ${props.cssStyles ?? ""}
       `}
       className={`${props.className ?? ""} ${props.fullHeight ? "full-height" : ""} ${props.fullWidth ? "full-width" : ""} ${

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hakit/core",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "private": false,
   "type": "module",
   "keywords": [

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -12,6 +12,8 @@ export { useHistory, type HistoryOptions } from "./useHistory";
 export { coordinates, type NumericEntityHistoryState, type coordinatesMinimalResponseCompressedState } from "./useHistory/coordinates";
 export { useSubscribeEntity } from "./useSubscribeEntity";
 export { useLogs, type UseLogOptions } from "./useLogs";
+export { useHaStatus } from "./useHaStatus";
+export { useConfig } from "./useConfig";
 export { useWeather, type UseWeatherOptions } from "./useWeather";
 export { getSupportedForecastTypes, type ForecastType, type ModernForecastType } from "./useWeather/helpers";
 export * from "./useLogs/logbook";

--- a/packages/core/src/hooks/useConfig/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useConfig/examples/basic.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useConfig } from "@hakit/core";
+
+export function Component() {
+  const config = useConfig();
+  return <div>Home Assistant Version: {config?.version}</div>;
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Component />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useConfig/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useConfig/examples/primary.stories.tsx
@@ -1,14 +1,14 @@
 import { HassConnect } from "hass-connect-fake";
-import { ThemeProvider } from "@hakit/components";
 import { Story } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
-import { Dashboard } from "./basic.code";
+import { Component } from "./basic.code";
+import { ThemeProvider } from "@hakit/components";
 
 function Primary() {
   return (
     <HassConnect hassUrl="http://homeassistant.local:8123">
       <ThemeProvider />
-      <Dashboard />
+      <Component />
     </HassConnect>
   );
 }

--- a/packages/core/src/hooks/useConfig/index.ts
+++ b/packages/core/src/hooks/useConfig/index.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState, useMemo } from "react";
+import { subscribeConfig, type HassConfig } from "home-assistant-js-websocket";
+import { useHass } from "@core";
+
+export function useConfig() {
+  const { useStore } = useHass();
+  const connection = useStore((state) => state.connection);
+  const [config, setConfig] = useState<HassConfig | null>(null);
+
+  useEffect(() => {
+    if (!connection) return;
+    // Subscribe to config updates
+    const unsubscribe = subscribeConfig(connection, (newConfig) => {
+      setConfig(newConfig);
+    });
+    // Cleanup function to unsubscribe on unmount
+    return () => {
+      unsubscribe();
+    };
+  }, [connection]); // Only re-run if connection changes
+
+  // Memoize the config to prevent unnecessary re-renders
+  return useMemo(() => config, [config]);
+}

--- a/packages/core/src/hooks/useConfig/useConfigDocs.mdx
+++ b/packages/core/src/hooks/useConfig/useConfigDocs.mdx
@@ -1,0 +1,24 @@
+import { Meta, Source, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useConfig" />
+
+# useConfig()
+###### `useConfig(): HassConfig | null`
+
+A custom React hook to subscribe to the Home Assistant configuration updates, this hook will return a new value every time your instance configuration changes.
+
+This hook will return the configuration object or null if not available yet.
+
+- **Dependencies**: This hook requires you to use it within the `HassConnect` component.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />
+
+

--- a/packages/core/src/hooks/useHaStatus/examples/basic.code.tsx
+++ b/packages/core/src/hooks/useHaStatus/examples/basic.code.tsx
@@ -1,0 +1,14 @@
+import { HassConnect, useHaStatus } from "@hakit/core";
+
+export function Component() {
+  const haStatus = useHaStatus();
+  return <div>Home Assistant Status: {haStatus}</div>;
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <Component />
+    </HassConnect>
+  );
+}

--- a/packages/core/src/hooks/useHaStatus/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useHaStatus/examples/primary.stories.tsx
@@ -1,0 +1,74 @@
+import { HassConnect } from "hass-connect-fake";
+import { Story } from "@storybook/blocks";
+import type { Meta, StoryObj } from "@storybook/react";
+import { Component } from "./basic.code";
+import { ThemeProvider, FabCard } from "@hakit/components";
+import { useHass } from "@hakit/core";
+import { Column, Row } from "@components";
+
+function ShutDown() {
+  const { useStore } = useHass();
+  const setConfig = useStore((state) => state.setConfig);
+  const config = useStore((state) => state.config);
+
+  if (!config) return null;
+  // This example code here will not actually trigger the shutdown in a real world scenario
+  // This is just to emulate the behavior of a real world scenario
+  return (
+    <Row gap="1rem">
+      <FabCard
+        cssStyles={`width: 200px`}
+        onClick={() => {
+          setConfig({ ...config, state: "STOPPING" });
+          setTimeout(() => setConfig({ ...config, state: "NOT_RUNNING" }), 1000);
+        }}
+        icon="mdi:power"
+      >
+        POWER OFF
+      </FabCard>
+      <FabCard
+        cssStyles={`width: 200px`}
+        onClick={() => {
+          setConfig({ ...config, state: "STARTING" });
+          setTimeout(() => setConfig({ ...config, state: "RUNNING" }), 1000);
+        }}
+        icon="mdi:power"
+      >
+        POWER UP
+      </FabCard>
+    </Row>
+  );
+}
+
+function Primary() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider />
+      <Column gap="1rem">
+        <ShutDown />
+        <Component />
+      </Column>
+    </HassConnect>
+  );
+}
+
+const meta: Meta<typeof Primary> = {
+  component: Primary,
+};
+
+export default meta;
+type Story = StoryObj<typeof Primary>;
+
+export const PrimaryExample: Story = {
+  args: {
+    label: "PrimaryExample",
+  },
+  tags: ["!dev"],
+  parameters: {
+    docs: {
+      canvas: {
+        sourceState: "none",
+      },
+    },
+  },
+};

--- a/packages/core/src/hooks/useHaStatus/index.ts
+++ b/packages/core/src/hooks/useHaStatus/index.ts
@@ -1,0 +1,25 @@
+import { useConfig } from "@core";
+import { type HassConfig } from "home-assistant-js-websocket";
+
+/**
+ * useHaStatus - A custom React hook to get the current status of the Home Assistant instance.
+ *
+ * This hook uses the `useHass` hook to access the Home Assistant context and retrieves the configuration state from the store.
+ *
+ * @returns {HassConfig["state"] | "LOADING"} - The current state of the Home Assistant configuration. If the configuration is not available, it returns 'LOADING'.
+ *
+ * Example usage:
+ * ```tsx
+ * import { useHaStatus } from '@core';
+ *
+ * const MyComponent = () => {
+ *   const haStatus = useHaStatus();
+ *
+ *   return <div>Home Assistant Status: {haStatus}</div>;
+ * };
+ * ```
+ */
+export function useHaStatus(): HassConfig["state"] | "LOADING" {
+  const config = useConfig();
+  return config?.state ?? "LOADING";
+}

--- a/packages/core/src/hooks/useHaStatus/useHaStatusDocs.mdx
+++ b/packages/core/src/hooks/useHaStatus/useHaStatusDocs.mdx
@@ -1,0 +1,25 @@
+import { Meta, Source, Canvas } from '@storybook/blocks';
+import basicExample from './examples/basic.code?raw';
+import * as Primary from './examples/primary.stories';
+
+<Meta title="core/hooks/useHaStatus" />
+
+# useHaStatus()
+###### `useHaStatus()`
+
+A custom React hook to get the current status of the Home Assistant instance.
+
+This hook uses the `useConfig` hook to access the Home Assistant configuration and retrieves the instance state from the config.
+
+- **Output**: "NOT_RUNNING" | "STARTING" | "RUNNING" | "STOPPING" | "FINAL_WRITE" | "LOADING"
+- **Dependencies**: This hook requires you to use it within the `HassConnect` component.
+
+### Example Usage
+
+<Source dark code={basicExample} />
+
+#### Outputs
+
+<Canvas of={Primary.PrimaryExample} />
+
+

--- a/packages/core/src/hooks/useHass/examples/useStore.code.tsx
+++ b/packages/core/src/hooks/useHass/examples/useStore.code.tsx
@@ -5,6 +5,7 @@ function UseStoreExample() {
   // there's more available on the store than displayed here, this is just an example
   const entities = useStore((store) => store.entities);
   const connection = useStore((store) => store.connection);
+  // A live update of the configuration
   const config = useStore((store) => store.config);
   const auth = useStore((store) => store.auth);
   console.log("data", {

--- a/packages/core/src/hooks/useHass/useHass.getConfig.mdx
+++ b/packages/core/src/hooks/useHass/useHass.getConfig.mdx
@@ -8,6 +8,8 @@ import getConfigExample from './examples/getConfig.code?raw';
 This will return all information about your configuration of your home assistant instance, this is all typed with typescript
 so you'll have access to what's available on the object with the `HassConfig` type.
 
+> Note: This function will only return the current configuration, it will not subscribe to updates, use the `useConfig` hook to get live updates.
+
 ### Definition
 <Source dark language="ts" code={`await getConfig()`} />
 

--- a/packages/core/src/hooks/useLightColor/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightColor/examples/primary.stories.tsx
@@ -24,6 +24,7 @@ export const PrimaryExample: Story = {
   args: {
     label: "PrimaryExample",
   },
+  tags: ["!dev"],
   parameters: {
     docs: {
       canvas: {

--- a/packages/core/src/hooks/useLightTemperature/examples/primary.stories.tsx
+++ b/packages/core/src/hooks/useLightTemperature/examples/primary.stories.tsx
@@ -24,6 +24,7 @@ export const PrimaryExample: Story = {
   args: {
     label: "PrimaryExample",
   },
+  tags: ["!dev"],
   parameters: {
     docs: {
       canvas: {

--- a/packages/create-hakit/package.json
+++ b/packages/create-hakit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-hakit",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "author": "Shannon Hochkins <mail@shannonhochkins.com>",
   "license": "ISC",

--- a/packages/create-hakit/src/index.ts
+++ b/packages/create-hakit/src/index.ts
@@ -63,7 +63,7 @@ async function validateHaUrl(haUrl: string): Promise<void> {
 
 
 // A functional approach to creating the project
-const createProject = async () => {  
+const createProject = async () => {
   try {
     let result: prompts.Answers<
       'projectName' | 'haUrl' | 'haToken'
@@ -227,6 +227,9 @@ const createProject = async () => {
     console.info(white(`\nAdd in the optional SSH values to your .env file to ensure that "npm run deploy" will work correctly.`));
     console.info(white(`\nTo retrieve the SSH information, follow the instructions here: https://shannonhochkins.github.io/ha-component-kit/?path=/docs/introduction-deploying--docs`));
     console.info();
+    if (haToken) {
+      console.info(yellow(`\nWARN: While the optional access token you provided is convenient for local development (and required for the \`npm run sync\` command) it is not recommended to be used when deploying to a home assistant server that has remote access enabled. It will make your hakit dashboard as well as the token itself public (not protected by the Home Assistant login screen) and accessible for everyone who can figure out the url to your dashboard.`));
+    }
     process.exit(status ?? 0)
 
   } catch (error) {
@@ -317,6 +320,8 @@ function updatePackageJson({
   const nodeScpVersion = getLatestNpmVersion('node-scp');
   const chalk = getLatestNpmVersion('chalk');
   const nodeTypesVersion = getLatestNpmVersion('@types/node');
+  const promptsVersion = getLatestNpmVersion('prompts');
+  const promptsTypeVersion = getLatestNpmVersion('@types/prompts');
   const packageFile = path.resolve(targetDir, 'package.json');
   const pkg = JSON.parse(fs.readFileSync(packageFile, 'utf-8'));
   pkg.dependencies = {
@@ -329,6 +334,8 @@ function updatePackageJson({
   pkg.devDependencies = {
     ...pkg.devDependencies,
     "prettier": `^${prettierVersion}`,
+    "prompts": `^${promptsVersion}`,
+    "@types/prompts": `^${promptsTypeVersion}`,
     "dotenv": `^${dotenvVersion}`,
     "@types/node": `^${nodeTypesVersion}`,
     "node-scp": `^${nodeScpVersion}`,


### PR DESCRIPTION
Here's a take on asking the user to confirm deployment to HA if the token is set. I also added a similar warning at the end of the create-hakit wizard if user supplies the token there. I realise that is what I did, added the optional token during setup without very much thought when I just wanted to get the project up and running with the create command. 

Feel free to change the wording of the warnings. Not entirely easy to write something succinct that gets the point across without being to verbose. Especially when English is not my first language :). My IDE added some minor whitespace and semicolon changes on-save as well. I let them stay, but could remove them if wanted. 

I've pretty much ignored everything in CONTRIBUTE.md since it felt like that didn't really cover the create-hakit package. and I'm also not really used to contributing to open source projects. So please tell me I should do this differently in any way! 