### PR TITLE
248 reported delays with card updates

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -107,6 +107,12 @@ export default {
       canvas: {
         sourceState: 'shown',
       },
+      source: {
+        dark: true,
+        language: 'tsx',
+        excludeDecorators: false,
+        format: 'dedent',
+      },
       page: Page
     }
   },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - NEW - TimeCard - when no time/date entity is provided, by default it will use the browsers time and date, this also uses a custom formatter to format the custom date string, previously the custom formatters only allowed you to specify strings per identifier, now you can return a ReactNode meaning we can have the same formatting behavior as if we have an entity (AM/PM suffix now wrapped in different styles.)
 - BREAKING - TimeCard - Unlikely breaking change for users unless you're potentially using css selectors targeting the h4 element in time cards, the h4 element is now a span to avoid nesting h4 elements after introducing the above feature.
-
+- IMPROVEMENT - Tooltip - A previously unknown behavior as something changed along the way, all tooltips were rendered on the page even before interacting with elements, and also continuously updating position on window resize, now tooltip elements are only created when interacting with the element with the tooltip, and removed from the dom after the interaction is complete, this should reduce the amount of elements on the page and improve performance.
 
 ### @hakit/core
 - useEntity - more issues with the useEntity hook causing delays in updates, the hook behind the scenes was using a debounce not a throttle which was not intended behavior, this seems to have resolved syncing issues with storybook and the actual dashboard.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 5.0.9
+
+### @hakit/components
+
+- NEW - TimeCard - when no time/date entity is provided, by default it will use the browsers time and date, this also uses a custom formatter to format the custom date string, previously the custom formatters only allowed you to specify strings per identifier, now you can return a ReactNode meaning we can have the same formatting behavior as if we have an entity (AM/PM suffix now wrapped in different styles.)
+
+
+### @hakit/core
+- useEntity - more issues with the useEntity hook causing delays in updates, the hook behind the scenes was using a debounce not a throttle which was not intended behavior, this seems to have resolved syncing issues with storybook and the actual dashboard.
+
+
 # 5.0.8
 
 ### @hakit/components

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - IMPROVEMENT - Tooltip - A previously unknown behavior as something changed along the way, all tooltips were rendered on the page even before interacting with elements, and also continuously updating position on window resize, now tooltip elements are only created when interacting with the element with the tooltip, and removed from the dom after the interaction is complete, this should reduce the amount of elements on the page and improve performance.
 
 ### @hakit/core
-- useEntity - more issues with the useEntity hook causing delays in updates, the hook behind the scenes was using a debounce not a throttle which was not intended behavior, this seems to have resolved syncing issues with storybook and the actual dashboard.
+- useEntity - more issues with the useEntity hook causing delays in updates, the hook behind the scenes was using a debounce not a throttle which was not intended behavior, this seems to have resolved syncing issues with storybook and the actual dashboard. [fixes](https://github.com/shannonhochkins/ha-component-kit/issues/248)
 
 
 # 5.0.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### @hakit/components
 
 - NEW - TimeCard - when no time/date entity is provided, by default it will use the browsers time and date, this also uses a custom formatter to format the custom date string, previously the custom formatters only allowed you to specify strings per identifier, now you can return a ReactNode meaning we can have the same formatting behavior as if we have an entity (AM/PM suffix now wrapped in different styles.)
+- BREAKING - TimeCard - Unlikely breaking change for users unless you're potentially using css selectors targeting the h4 element in time cards, the h4 element is now a span to avoid nesting h4 elements after introducing the above feature.
 
 
 ### @hakit/core

--- a/hakit/server/default.html
+++ b/hakit/server/default.html
@@ -110,7 +110,6 @@
       .catch(error => console.error('Error:', error));
     }
     function runApplication() {
-      console.log('xx', `${baseUrl}run-application`);
       fetch(`${baseUrl}api/v1/run-application`, {
         method: 'POST'
       })

--- a/hass-connect-fake/index.tsx
+++ b/hass-connect-fake/index.tsx
@@ -450,7 +450,7 @@ function HassProvider({
           state: formatted
         }
       });
-    }, 60000);
+    }, 125);
     return () => {
       if (clock.current) clearInterval(clock.current);
     }

--- a/hass-connect-fake/index.tsx
+++ b/hass-connect-fake/index.tsx
@@ -437,13 +437,12 @@ function HassProvider({
         last_changed: now.toISOString(),
         last_updated: now.toISOString(),
       }
-      setEntities({
-        ['sensor.time']: {
-          ...entities['sensor.time'],
-          ...dates,
-          state: formatted
-        }
-      });
+      entities['sensor.time'] = {
+        ...entities['sensor.time'],
+        ...dates,
+        state: formatted
+      }
+      setEntities(entities);
     }, 125);
     return () => {
       if (clock.current) clearInterval(clock.current);

--- a/packages/components/src/Cards/SidebarCard/index.tsx
+++ b/packages/components/src/Cards/SidebarCard/index.tsx
@@ -29,7 +29,7 @@ const StyledTimeCard = styled(TimeCard)<{
       color: var(--ha-S200-contrast);
     }
   }
-  h4 {
+  .time, .time-suffix {
     transition: var(--ha-transition-duration) var(--ha-easing);
     transition-property: font-size;
   }
@@ -37,7 +37,7 @@ const StyledTimeCard = styled(TimeCard)<{
     !props.open &&
     `
     padding: 0.5rem 0;
-    h4 {
+    .time, .time-suffix {
       font-size: 0.7rem;
     }
   `}

--- a/packages/components/src/Cards/TimeCard/TimeCard.stories.tsx
+++ b/packages/components/src/Cards/TimeCard/TimeCard.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ThemeProvider, Row, TimeCard, ThemeControlsModal, Alert } from "@components";
 import type { TimeCardProps } from "@components";
 import { HassConnect } from "@hass-connect-fake";
-import { Source } from "@storybook/blocks";
 
 function Template(args?: Partial<TimeCardProps>) {
   return (
@@ -12,6 +11,12 @@ function Template(args?: Partial<TimeCardProps>) {
       <Row gap="1rem">
         <TimeCard {...args} />
         <TimeCard timeFormat="hh:mm:ss A" dateFormat={"MMM DD"} {...args} />
+        <TimeCard
+          timeFormat={(date) => {
+            return "Time: " + date.toLocaleTimeString().replace(/:/g, "-");
+          }}
+          hideDate
+        />
       </Row>
       <Alert
         type="warning"
@@ -35,24 +40,6 @@ function Template(args?: Partial<TimeCardProps>) {
           .
         </p>
       </Alert>
-      <p>You can provide your own custom formatters:</p>
-      <TimeCard
-        timeFormat={(date) => {
-          return "Time: " + date.toLocaleTimeString().replace(/:/g, "-");
-        }}
-        hideDate
-        {...args}
-      />
-      <Source
-        code={`<TimeCard
-  timeFormat={(date) => {
-    return "Time: " + date.toLocaleTimeString().replace(/:/g, "-");
-  }}
-  hideDate
-/>`}
-        dark
-        language="tsx"
-      />
     </HassConnect>
   );
 }
@@ -78,6 +65,15 @@ export type TimeStory = StoryObj<typeof TimeCard>;
 export const Docs: TimeStory = {
   render: Template,
   args: {},
+  parameters: {
+    docs: {
+      source: {
+        // language: 'graphql',
+        dark: false,
+        excludeDecorators: false,
+      },
+    },
+  },
 };
 
 export const WithoutDateExample: TimeStory = {

--- a/packages/components/src/Cards/TimeCard/TimeCard.stories.tsx
+++ b/packages/components/src/Cards/TimeCard/TimeCard.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ThemeProvider, Row, TimeCard, ThemeControlsModal, Alert } from "@components";
 import type { TimeCardProps } from "@components";
 import { HassConnect } from "@hass-connect-fake";
+import { Source } from "@storybook/blocks";
 
 function Template(args?: Partial<TimeCardProps>) {
   return (
@@ -10,14 +11,7 @@ function Template(args?: Partial<TimeCardProps>) {
       <ThemeControlsModal />
       <Row gap="1rem">
         <TimeCard {...args} />
-        <TimeCard timeFormat="hh:mm:ss a" dateFormat={"MMM DD"} {...args} />
-        <TimeCard
-          timeFormat={(date) => {
-            return "WHAT? " + date.toLocaleTimeString().replace(/:/g, "-");
-          }}
-          hideDate
-          {...args}
-        />
+        <TimeCard timeFormat="hh:mm:ss A" dateFormat={"MMM DD"} {...args} />
       </Row>
       <Alert
         type="warning"
@@ -41,6 +35,22 @@ function Template(args?: Partial<TimeCardProps>) {
           .
         </p>
       </Alert>
+      <p>You can provide your own custom formatters:</p>
+      <TimeCard
+        timeFormat={(date) => {
+          return "Time: " + date.toLocaleTimeString().replace(/:/g, "-");
+        }}
+        hideDate
+        {...args}
+      />
+      <Source code={
+`<TimeCard
+  timeFormat={(date) => {
+    return "Time: " + date.toLocaleTimeString().replace(/:/g, "-");
+  }}
+  hideDate
+/>`
+      } dark language="tsx" />
     </HassConnect>
   );
 }

--- a/packages/components/src/Cards/TimeCard/TimeCard.stories.tsx
+++ b/packages/components/src/Cards/TimeCard/TimeCard.stories.tsx
@@ -43,14 +43,16 @@ function Template(args?: Partial<TimeCardProps>) {
         hideDate
         {...args}
       />
-      <Source code={
-`<TimeCard
+      <Source
+        code={`<TimeCard
   timeFormat={(date) => {
     return "Time: " + date.toLocaleTimeString().replace(/:/g, "-");
   }}
   hideDate
-/>`
-      } dark language="tsx" />
+/>`}
+        dark
+        language="tsx"
+      />
     </HassConnect>
   );
 }

--- a/packages/components/src/Cards/TimeCard/formatter.tsx
+++ b/packages/components/src/Cards/TimeCard/formatter.tsx
@@ -165,13 +165,13 @@ function formatDate(customFormatters: CustomFormatters, format: string, parts: D
       const val = format.slice(lastIndex, offset);
       if (val.length > 0 && val.trim().length === 0) {
         // whitespace char
-        tokens.push(<span className="whitespace">&nbsp;</span>)
+        tokens.push(<span className="whitespace">&nbsp;</span>);
       } else {
         tokens.push(val);
       }
     }
     lastIndex = offset + mask.length;
-    
+
     if (literal) {
       // If we matched [literal text], just push that as plain text
       tokens.push(literal);
@@ -182,8 +182,8 @@ function formatDate(customFormatters: CustomFormatters, format: string, parts: D
     // Return an empty string to discard the normal replace output
     return "";
   });
-   // If there's still text remaining after the last match, push it
-   if (lastIndex < format.length) {
+  // If there's still text remaining after the last match, push it
+  if (lastIndex < format.length) {
     tokens.push(format.slice(lastIndex));
   }
   // Finally, render the HTML string inside React. We must do dangerouslySetInnerHTML

--- a/packages/components/src/Cards/TimeCard/formatter.tsx
+++ b/packages/components/src/Cards/TimeCard/formatter.tsx
@@ -2,13 +2,14 @@ import {
   CustomFormatters,
   DateParts,
   Formatters,
-  FormatFunction,
   FormatterMask,
   DatePartName,
   FormatOptions,
+  FormatFunction,
   Parser,
   Token,
 } from "./types";
+import { AmOrPm } from "./shared";
 
 const parsers: Map<string, Parser> = new Map();
 
@@ -30,7 +31,7 @@ const intlFormattersOptions = [
 ] satisfies Partial<Intl.DateTimeFormatOptions>[];
 
 export function createDateFormatter(customFormatters: CustomFormatters): FormatFunction {
-  return function intlFormatDate(date: Date, format: string, options?: FormatOptions): string {
+  return function intlFormatDate(date: Date, format: string, options?: FormatOptions): React.ReactNode {
     const tokens = parseDate(date, options);
     const output = formatDate(customFormatters, format, tokens, date);
     return output;
@@ -135,8 +136,8 @@ const formatters: Formatters = {
   ddx: (parts) => `${parseInt(parts.day, 10)}${daySuffix(parseInt(parts.day))}`,
   dddd: (parts) => parts.weekday,
   ddd: (parts) => parts.weekday.slice(0, 3),
-  A: (parts) => parts.dayPeriod,
-  a: (parts) => parts.dayPeriod.toLowerCase(),
+  A: (parts) => <AmOrPm className="time-suffix">{parts.dayPeriod}</AmOrPm>,
+  a: (parts) => <AmOrPm className="time-suffix">{parts.dayPeriod.toLowerCase()}</AmOrPm>,
   // XXX: fix Chrome 80+ bug going over 24h
   HH: (parts) => ("0" + (Number(parts.lhour) % 24)).slice(-2),
   hh: (parts) => parts.hour,
@@ -146,14 +147,46 @@ const formatters: Formatters = {
 
 const createCustomPattern = (customFormatters: CustomFormatters) => Object.keys(customFormatters).reduce((_, key) => `|${key}`, "");
 
-function formatDate(customFormatters: CustomFormatters, format: string, parts: DateParts, date: Date): string {
+function formatDate(customFormatters: CustomFormatters, format: string, parts: DateParts, date: Date): React.ReactNode {
   const literalPattern = "\\[([^\\]]+)\\]|";
   const customPattern = createCustomPattern(customFormatters);
   const patternRegexp = new RegExp(`${literalPattern}${defaultPattern}${customPattern}`, "g");
 
   const allFormatters = { ...formatters, ...customFormatters };
-  // @ts-expect-error - fix later
-  return format.replace(patternRegexp, (mask: FormatterMask, literal: string) => {
-    return literal || allFormatters[mask](parts, date);
+  // We'll accumulate text/JSX in an array
+  const tokens: React.ReactNode[] = [];
+  let lastIndex = 0;
+  // @ts-expect-error - will fix later
+  format.replace(patternRegexp, (mask: FormatterMask, literal: string, offset: number) => {
+    // 'offset' is the index of this match within the full format string
+
+    // Push any text that occurs before this match
+    if (offset > lastIndex) {
+      const val = format.slice(lastIndex, offset);
+      if (val.length > 0 && val.trim().length === 0) {
+        // whitespace char
+        tokens.push(<span className="whitespace">&nbsp;</span>)
+      } else {
+        tokens.push(val);
+      }
+    }
+    lastIndex = offset + mask.length;
+    
+    if (literal) {
+      // If we matched [literal text], just push that as plain text
+      tokens.push(literal);
+    } else {
+      // Everything else just push normally
+      tokens.push(allFormatters[mask](parts, date));
+    }
+    // Return an empty string to discard the normal replace output
+    return "";
   });
+   // If there's still text remaining after the last match, push it
+   if (lastIndex < format.length) {
+    tokens.push(format.slice(lastIndex));
+  }
+  // Finally, render the HTML string inside React. We must do dangerouslySetInnerHTML
+  // so that <div> ... </div> is recognized as HTML, not plain text:
+  return <>{tokens}</>;
 }

--- a/packages/components/src/Cards/TimeCard/index.tsx
+++ b/packages/components/src/Cards/TimeCard/index.tsx
@@ -6,6 +6,7 @@ import { Row, Column, fallback, CardBase, type CardBaseProps, type AvailableQuer
 import { createDateFormatter, daySuffix } from "./formatter";
 import { ErrorBoundary } from "react-error-boundary";
 import { FormatFunction } from "./types";
+import { Time, AmOrPm } from "./shared";
 
 const Card = styled(CardBase)`
   cursor: default;
@@ -29,20 +30,6 @@ const Contents = styled.div`
   }
 `;
 
-const Time = styled.h4`
-  all: unset;
-  font-family: var(--ha-font-family);
-  font-size: 2rem;
-  color: var(--ha-S200-contrast);
-  font-weight: 400;
-`;
-const AmOrPm = styled.h4`
-  all: unset;
-  font-family: var(--ha-font-family);
-  font-size: 2rem;
-  color: var(--ha-S400-contrast);
-  font-weight: 300;
-`;
 
 function convertTo12Hour(time: string) {
   // Create a new Date object
@@ -87,7 +74,7 @@ function formatDate(dateString: string): string {
 
   return formattedDate;
 }
-type CustomFormatter = (date: Date, formatter: FormatFunction) => string;
+type CustomFormatter = (date: Date, formatter: FormatFunction) => React.ReactNode;
 type OmitProperties = "title" | "as" | "active" | "entity" | "service" | "serviceData" | "longPressCallback" | "modalProps";
 export interface TimeCardProps extends Omit<CardBaseProps<"div">, OmitProperties> {
   /** provide a custom entity to read the time from, if not found/provided it will update from machine time @default "sensor.time" */

--- a/packages/components/src/Cards/TimeCard/index.tsx
+++ b/packages/components/src/Cards/TimeCard/index.tsx
@@ -30,7 +30,6 @@ const Contents = styled.div`
   }
 `;
 
-
 function convertTo12Hour(time: string) {
   // Create a new Date object
   const [hour, minute] = time.split(":");
@@ -103,7 +102,7 @@ export interface TimeCardProps extends Omit<CardBaseProps<"div">, OmitProperties
   onClick?: (entity: HassEntityWithService<"sensor">, event: React.MouseEvent<HTMLElement, MouseEvent>) => void;
 }
 
-const DEFAULT_TIME_FORMAT = "hh:mm a";
+const DEFAULT_TIME_FORMAT = "hh:mm A";
 const DEFAULT_DATE_FORMAT = "dddd, MMMM DD YYYY";
 
 const customFormatter = createDateFormatter({});
@@ -160,9 +159,7 @@ function InternalTimeCard({
     try {
       return (
         <Time className="time">
-          {typeof timeFormat === "function"
-            ? timeFormat(currentTime, customFormatter)
-            : customFormatter(currentTime, timeFormat ?? DEFAULT_TIME_FORMAT)}
+          {typeof timeFormat === "function" ? timeFormat(currentTime, customFormatter) : customFormatter(currentTime, timeFormat)}
         </Time>
       );
     } catch (e) {
@@ -196,10 +193,12 @@ function InternalTimeCard({
   }, [throttleTime]);
 
   useEffect(() => {
-    if (!timeFormat && !dateFormat) return; // let home assistant trigger updates
+    const hasEntities = timeSensor || dateSensor;
+    const hasFormatters = timeFormat || dateFormat;
+    if (hasEntities && !hasFormatters) return; // let home assistant trigger updates
     requestRef.current = requestAnimationFrame(updateClock);
     return () => cancelAnimationFrame(requestRef.current!);
-  }, [updateClock, timeFormat, dateFormat]);
+  }, [updateClock, timeFormat, dateFormat, timeSensor, dateSensor]);
 
   return (
     <Card

--- a/packages/components/src/Cards/TimeCard/index.tsx
+++ b/packages/components/src/Cards/TimeCard/index.tsx
@@ -138,6 +138,7 @@ function InternalTimeCard({
   const dateSensor = useEntity(dateEntity ?? "sensor.date", {
     returnNullIfNotFound: true,
   });
+  const dateIcon = useMemo(() => icon || dateSensor?.attributes?.icon || "mdi:calendar", [icon, dateSensor]);
   const [formatted, amOrPm] = useMemo(() => {
     const parts = convertTo12Hour(timeSensor?.state ?? "00:00");
     const hour = parts.find((part) => part.type === "hour");
@@ -159,7 +160,7 @@ function InternalTimeCard({
     try {
       return (
         <Time className="time">
-          {typeof timeFormat === "function" ? timeFormat(currentTime, customFormatter) : customFormatter(currentTime, timeFormat)}
+          {typeof timeFormat === "function" ? timeFormat(currentTime, customFormatter) : customFormatter(currentTime, timeFormat ?? DEFAULT_TIME_FORMAT)}
         </Time>
       );
     } catch (e) {
@@ -223,7 +224,7 @@ function InternalTimeCard({
           {(!hideIcon || !hideTime) && (
             <Row className="row" gap="0.5rem" alignItems="center" wrap="nowrap">
               {!hideIcon && (
-                <Icon className="icon primary-icon" icon={icon || dateSensor?.attributes?.icon || "mdi:calendar"} {...(iconProps ?? {})} />
+                <Icon className="icon primary-icon" icon={dateIcon} {...(iconProps ?? {})} />
               )}
               {!hideTime && timeValue}
             </Row>

--- a/packages/components/src/Cards/TimeCard/shared.tsx
+++ b/packages/components/src/Cards/TimeCard/shared.tsx
@@ -1,0 +1,19 @@
+import styled from "@emotion/styled";
+
+export const Time = styled.h4`
+  all: unset;
+  font-family: var(--ha-font-family);
+  font-size: 2rem;
+  color: var(--ha-S200-contrast);
+  font-weight: 400;
+  display: flex;
+  flex-direction: row;
+`;
+
+export const AmOrPm = styled.h4`
+  all: unset;
+  font-family: var(--ha-font-family);
+  font-size: 2rem;
+  color: var(--ha-S400-contrast);
+  font-weight: 300;
+`;

--- a/packages/components/src/Cards/TimeCard/shared.tsx
+++ b/packages/components/src/Cards/TimeCard/shared.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled";
 
-export const Time = styled.h4`
+export const Time = styled.span`
   all: unset;
   font-family: var(--ha-font-family);
   font-size: 2rem;
@@ -10,7 +10,7 @@ export const Time = styled.h4`
   flex-direction: row;
 `;
 
-export const AmOrPm = styled.h4`
+export const AmOrPm = styled.span`
   all: unset;
   font-family: var(--ha-font-family);
   font-size: 2rem;

--- a/packages/components/src/Cards/TimeCard/types.ts
+++ b/packages/components/src/Cards/TimeCard/types.ts
@@ -25,13 +25,13 @@ export type FormatterMask =
   | "mm"
   | "ss";
 
-export type Formatter = (tokens: DateParts, date: Date) => string;
+export type Formatter = (tokens: DateParts, date: Date) => React.ReactNode;;
 
 export type Formatters = { [k in FormatterMask]: Formatter };
 
 export type CustomFormatters = { [k: string]: Formatter };
 
-export type FormatFunction = (date: Date, format: string, options?: FormatOptions) => string;
+export type FormatFunction = (date: Date, format: string, options?: FormatOptions) => React.ReactNode;
 
 export type FormatOptions = {
   locale?: string;

--- a/packages/components/src/Cards/TimeCard/types.ts
+++ b/packages/components/src/Cards/TimeCard/types.ts
@@ -25,7 +25,7 @@ export type FormatterMask =
   | "mm"
   | "ss";
 
-export type Formatter = (tokens: DateParts, date: Date) => React.ReactNode;;
+export type Formatter = (tokens: DateParts, date: Date) => React.ReactNode;
 
 export type Formatters = { [k in FormatterMask]: Formatter };
 

--- a/packages/components/src/Shared/Tooltip/index.tsx
+++ b/packages/components/src/Shared/Tooltip/index.tsx
@@ -16,7 +16,7 @@ const TooltipSpan = styled.span<Pick<TooltipProps, "placement">>`
   box-shadow: 0px 2px 4px var(--ha-S100);
   font-size: 0.9rem;
   z-index: 1000;
-  visibility: hidde;
+  visibility: hidden;
   opacity: 0;
   transition: var(--ha-transition-duration) var(--ha-easing);
   transition-property: opacity, visibility;

--- a/packages/components/src/ThemeProvider/index.tsx
+++ b/packages/components/src/ThemeProvider/index.tsx
@@ -33,7 +33,14 @@ export type ThemeProviderProps<T extends object> = ThemeStore["theme"] & {
   theme?: DeepPartial<ThemeParams> & T;
   /** any global style overrides */
   globalStyles?: CSSInterpolation;
-  /** options to pass to the emotion cache provider */
+  /** options to pass to the emotion cache provider, if an emotion cache is provided, or a different window context via HassConnect, you'll need to wrap your dashboard in the ThemeProvider
+   * otherwise the styles will not be applied correctly to child components.
+   * @example
+   * ```tsx
+   * <ThemeProvider emotionCache={{ key: "my-key", container: myContainer }}>
+   *  <App />
+   * </ThemeProvider>
+   */
   emotionCache?: Options;
   /** default breakpoint media query overrides @default {
    * xxs: 600,

--- a/packages/components/src/ThemeProvider/index.tsx
+++ b/packages/components/src/ThemeProvider/index.tsx
@@ -205,9 +205,11 @@ const generateAllVars = (tint: number, darkMode: boolean): string => {
   `;
 };
 
-function omitXlg(breakpoints: BreakPoints & {
-  xlg: number;
-}): BreakPoints {
+function omitXlg(
+  breakpoints: BreakPoints & {
+    xlg: number;
+  },
+): BreakPoints {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { xlg, ...rest } = breakpoints;
   return rest;

--- a/packages/core/src/hooks/useEntity/index.ts
+++ b/packages/core/src/hooks/useEntity/index.ts
@@ -149,6 +149,8 @@ export function useEntity<E extends EntityName, O extends UseEntityOptions = Use
     }
   }, [matchedEntity, $entity, formatEntity]);
 
+
+
   return useMemo(() => {
     if ($entity === null) {
       // purposely casting here so types are correct on usage side

--- a/packages/core/src/hooks/useEntity/index.ts
+++ b/packages/core/src/hooks/useEntity/index.ts
@@ -6,7 +6,7 @@ import { useSubscribeEntity } from "../useSubscribeEntity";
 import { useService } from "../useService";
 import { useHistory } from "../useHistory";
 import { getIconByEntity } from "../useIcon";
-import { useDebouncedCallback } from "use-debounce";
+import { useThrottledCallback } from "use-debounce";
 import { getCssColorValue } from "@utils/colors";
 import { computeDomain } from "@utils/computeDomain";
 import { diff } from "deep-object-diff";
@@ -21,7 +21,7 @@ interface UseEntityOptions {
   historyOptions?: HistoryOptions;
 }
 
-const DEFAULT_OPTIONS: UseEntityOptions = {
+const DEFAULT_OPTIONS: Required<UseEntityOptions> = {
   throttle: 25,
   returnNullIfNotFound: false,
   historyOptions: {
@@ -81,7 +81,7 @@ export function useEntity<E extends EntityName, O extends UseEntityOptions = Use
     },
     [language],
   );
-  const debounceUpdate = useDebouncedCallback(
+  const debounceUpdate = useThrottledCallback(
     (entity: HassEntity) => {
       setEntity(formatEntity(entity));
     },

--- a/packages/core/src/hooks/useWeather/index.ts
+++ b/packages/core/src/hooks/useWeather/index.ts
@@ -42,7 +42,7 @@ export function useWeather(entityId: FilterByDomain<EntityName, "weather">, opti
     [connection],
   );
 
-  const debounceSubscribeLogbookPeriod = useDebouncedCallback(
+  const debounceSubscribeWeatherEvents = useDebouncedCallback(
     async (entityId: FilterByDomain<EntityName, "weather">, type: ModernForecastType) => {
       if (_unsubscribe.current) {
         const unsubscribe = await _unsubscribe.current;
@@ -60,7 +60,7 @@ export function useWeather(entityId: FilterByDomain<EntityName, "weather">, opti
   );
 
   useEffect(() => {
-    debounceSubscribeLogbookPeriod(entityId, type);
+    debounceSubscribeWeatherEvents(entityId, type);
 
     return () => {
       _subscribed.current = false;
@@ -68,7 +68,7 @@ export function useWeather(entityId: FilterByDomain<EntityName, "weather">, opti
         _unsubscribe.current();
       }
     };
-  }, [type, debounceSubscribeLogbookPeriod, subscribeWeatherEvents, entityId]);
+  }, [type, debounceSubscribeWeatherEvents, subscribeWeatherEvents, entityId]);
 
   if (error) {
     throw error;


### PR DESCRIPTION
# 5.0.9

### @hakit/components

- NEW - TimeCard - when no time/date entity is provided, by default it will use the browsers time and date, this also uses a custom formatter to format the custom date string, previously the custom formatters only allowed you to specify strings per identifier, now you can return a ReactNode meaning we can have the same formatting behavior as if we have an entity (AM/PM suffix now wrapped in different styles.)
- BREAKING - TimeCard - Unlikely breaking change for users unless you're potentially using css selectors targeting the h4 element in time cards, the h4 element is now a span to avoid nesting h4 elements after introducing the above feature.
- IMPROVEMENT - Tooltip - A previously unknown behavior as something changed along the way, all tooltips were rendered on the page even before interacting with elements, and also continuously updating position on window resize, now tooltip elements are only created when interacting with the element with the tooltip, and removed from the dom after the interaction is complete, this should reduce the amount of elements on the page and improve performance.

### @hakit/core
- useEntity - more issues with the useEntity hook causing delays in updates, the hook behind the scenes was using a debounce not a throttle which was not intended behavior, this seems to have resolved syncing issues with storybook and the actual dashboard.

### Storybook
Updated clock updates to every 250ms instead of 60s, this was causing issues seeing time values update differently