### PR TITLE
Optional breakpoints

### DIFF
--- a/hass-connect-fake/index.tsx
+++ b/hass-connect-fake/index.tsx
@@ -34,8 +34,6 @@ import { mockCallApi } from './mocks/fake-call-api';
 import reolinkSnapshot from './assets/reolink-snapshot.jpg';
 import { logs } from './mocks/mockLogs';
 import {dailyForecast, hourlyForecast} from './mocks/mockWeather';
-import { DEFAULT_BREAKPOINTS } from '../packages/core/src/HassConnect/HassContext'
-
 interface HassProviderProps {
   children: (ready: boolean) => ReactNode;
   hassUrl: string;
@@ -303,13 +301,6 @@ const useStore = create<Store>((set) => ({
   callApi: async (): Promise<unknown> => {
     return {};
   },
-  /** getter for breakpoints, if using @hakit/components, the breakpoints are stored here to retrieve in different locations */
-  breakpoints: DEFAULT_BREAKPOINTS,
-  /** setter for breakpoints, if using @hakit/components, the breakpoints are stored here to retrieve in different locations */
-  setBreakpoints: (breakpoints) => set({ breakpoints: {
-    ...breakpoints,
-    xlg: breakpoints.lg + 1,
-  } }),
   globalComponentStyles: {},
   setGlobalComponentStyles: (globalComponentStyles) => set({ globalComponentStyles }),
 }))

--- a/packages/components/src/Cards/EntitiesCard/EntitiesCard.stories.tsx
+++ b/packages/components/src/Cards/EntitiesCard/EntitiesCard.stories.tsx
@@ -37,7 +37,6 @@ function Render(args?: Args) {
 export default {
   title: "components/Cards/EntitiesCard",
   component: EntitiesCard,
-  // @ts-expect-error - will fix later
   subcomponents: { EntitiesCardRow },
   tags: ["autodocs"],
   parameters: {

--- a/packages/components/src/Shared/Entity/Miscellaneous/ButtonBar/ButtonBar.stories.tsx
+++ b/packages/components/src/Shared/Entity/Miscellaneous/ButtonBar/ButtonBar.stories.tsx
@@ -39,7 +39,6 @@ function Template(args?: Partial<ButtonBarProps>) {
 export default {
   title: "components/Shared/Entity/Miscellaneous/ButtonBar",
   component: ButtonBar,
-  // @ts-expect-error - will fix later
   subcomponents: { ButtonBarButton },
   tags: ["autodocs"],
   parameters: {

--- a/packages/components/src/Shared/Entity/Miscellaneous/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/components/src/Shared/Entity/Miscellaneous/ButtonGroup/ButtonGroup.stories.tsx
@@ -26,7 +26,6 @@ function Template(args?: Partial<ButtonGroupProps>) {
 export default {
   title: "components/Shared/Entity/Miscellaneous/ButtonGroup",
   component: ButtonGroup,
-  // @ts-expect-error - will fix later
   subcomponents: { ButtonGroupButton },
   tags: ["autodocs"],
   parameters: {

--- a/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
+++ b/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
@@ -183,8 +183,8 @@ export type CustomBreakpoints = StoryObj<typeof Empty>;
 export const CustomBreakpoints: Story = {
   render: Empty,
   parameters: {
-    redirectTo: '/story/components-hooks-usebreakpoint--custom-breakpoints',
-  }
+    redirectTo: "/story/components-hooks-usebreakpoint--custom-breakpoints",
+  },
 };
 
-CustomBreakpoints.storyName = 'Custom Breakpoints';
+CustomBreakpoints.storyName = "Custom Breakpoints";

--- a/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
+++ b/packages/components/src/ThemeProvider/ThemeProvider.stories.tsx
@@ -176,3 +176,15 @@ export const Docs: Story = {
     theme,
   },
 };
+
+const Empty = () => <></>;
+
+export type CustomBreakpoints = StoryObj<typeof Empty>;
+export const CustomBreakpoints: Story = {
+  render: Empty,
+  parameters: {
+    redirectTo: '/story/components-hooks-usebreakpoint--custom-breakpoints',
+  }
+};
+
+CustomBreakpoints.storyName = 'Custom Breakpoints';

--- a/packages/components/src/ThemeProvider/breakpoints.ts
+++ b/packages/components/src/ThemeProvider/breakpoints.ts
@@ -25,7 +25,6 @@ export type BreakPoints = Partial<Record<Exclude<BreakPoint, "xlg">, number>>;
 export type BreakPointsWithXlg = Partial<Record<BreakPoint, number>>;
 
 export const getBreakpoints = (breakpoints: BreakPoints) => {
-  console.log("breakpoints", breakpoints);
   const definedEntries = orderedBreakpoints
     .filter((key) => breakpoints[key] !== undefined)
     .map((key) => [key, breakpoints[key]!] as [Exclude<BreakPoint, "xlg">, number]);

--- a/packages/components/src/ThemeProvider/constants.ts
+++ b/packages/components/src/ThemeProvider/constants.ts
@@ -15,3 +15,12 @@ export const DEFAULT_THEME_OPTIONS = {
   lightness: 54,
   contrastThreshold: 65,
 } as const;
+
+export const DEFAULT_BREAKPOINTS = {
+  xxs: 600,
+  xs: 900,
+  sm: 1200,
+  md: 1536,
+  lg: 1700,
+  xlg: 1701,
+};

--- a/packages/components/src/ThemeProvider/index.tsx
+++ b/packages/components/src/ThemeProvider/index.tsx
@@ -5,7 +5,7 @@ import { isEqual, merge } from "lodash";
 import { theme as defaultTheme } from "./theme";
 import type { ThemeParams } from "./theme";
 import { convertToCssVars } from "./helpers";
-import { useBreakpoint, fallback, type BreakPoints } from "@components";
+import { useBreakpoint, fallback, type BreakPoints, type BreakPointsWithXlg } from "@components";
 import { ErrorBoundary } from "react-error-boundary";
 import { LIGHT, DARK, ACCENT, DEFAULT_START_LIGHT, DEFAULT_START_DARK, DIFF, DEFAULT_THEME_OPTIONS } from "./constants";
 import { useHass, type SupportedComponentOverrides } from "@hakit/core";
@@ -205,11 +205,7 @@ const generateAllVars = (tint: number, darkMode: boolean): string => {
   `;
 };
 
-function omitXlg(
-  breakpoints: BreakPoints & {
-    xlg: number;
-  },
-): BreakPoints {
+function omitXlg(breakpoints: BreakPointsWithXlg): BreakPoints {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { xlg, ...rest } = breakpoints;
   return rest;
@@ -232,9 +228,9 @@ const InternalThemeProvider = memo(function InternalThemeProvider<T extends obje
   const { useStore } = useHass();
   const themeStore = useThemeStore((store) => store.theme);
   const setTheme = useThemeStore((store) => store.setTheme);
-  const setBreakpoints = useStore((store) => store.setBreakpoints);
+  const setBreakpoints = useThemeStore((store) => store.setBreakpoints);
   const setGlobalComponentStyles = useStore((store) => store.setGlobalComponentStyles);
-  const _breakpoints = useStore((store) => store.breakpoints);
+  const _breakpoints = useThemeStore((store) => store.breakpoints);
   const device = useBreakpoint();
   const windowContext = useStore((store) => store.windowContext);
   const win = windowContext ?? window;

--- a/packages/components/src/ThemeProvider/store.ts
+++ b/packages/components/src/ThemeProvider/store.ts
@@ -1,5 +1,6 @@
 import { create } from "zustand";
-import { DEFAULT_THEME_OPTIONS } from "./constants";
+import { DEFAULT_THEME_OPTIONS, DEFAULT_BREAKPOINTS } from "./constants";
+import { BreakPoints, BreakPointsWithXlg } from "@components";
 
 export type ThemeStore = {
   theme: {
@@ -18,6 +19,10 @@ export type ThemeStore = {
   };
   /** Will merge input theme values with the default values, undefined values passed through the setTheme function will be ignored */
   setTheme: (partialTheme: ThemeStore["theme"]) => void;
+  /** getter for breakpoints, if using @hakit/components, the breakpoints are stored here to retrieve in different locations */
+  breakpoints: BreakPointsWithXlg;
+  /** setter for breakpoints, intended for internal use only */
+  setBreakpoints: (breakpoints: BreakPoints) => void;
 };
 
 export const useThemeStore = create<ThemeStore>((set) => ({
@@ -37,5 +42,23 @@ export const useThemeStore = create<ThemeStore>((set) => ({
         ...Object.fromEntries(Object.entries(partialTheme).filter(([, value]) => value !== undefined)),
       },
     }));
+  },
+  breakpoints: DEFAULT_BREAKPOINTS,
+  setBreakpoints: (breakpoints) => {
+    // there should at least be ONE breakpoint defined, get the largest value from the breakpoints object
+    // if the object is empty or no values with numbers, it should throw an error
+    if (Object.keys(breakpoints).length === 0) {
+      throw new Error("No breakpoints provided");
+    }
+    const largestValue = Math.max(...Object.values(breakpoints).filter((value) => typeof value === "number"));
+    if (largestValue === -Infinity) {
+      throw new Error("No valid breakpoints provided");
+    }
+    set({
+      breakpoints: {
+        ...breakpoints,
+        xlg: largestValue + 1,
+      },
+    });
   },
 }));

--- a/packages/components/src/hooks/examples/some-breakpoints.code.tsx
+++ b/packages/components/src/hooks/examples/some-breakpoints.code.tsx
@@ -1,0 +1,30 @@
+import { HassConnect } from "@hakit/core";
+import { useBreakpoint, ThemeProvider } from "@hakit/components";
+
+export function Component() {
+  const bp = useBreakpoint();
+  return (
+    <div>
+      {bp.xxs && <p>xxs active</p>}
+      {bp.xs && <p>xs active</p>}
+      {bp.sm && <p>sm active</p>}
+      {bp.md && <p>md active</p>}
+      {bp.lg && <p>lg active</p>}
+      {bp.xlg && <p>xlg active</p>}
+    </div>
+  );
+}
+
+export function App() {
+  return (
+    <HassConnect hassUrl="http://localhost:8123">
+      <ThemeProvider
+        breakpoints={{
+          xs: 576,
+          lg: 1200,
+        }}
+      />
+      <Component />
+    </HassConnect>
+  );
+}

--- a/packages/components/src/hooks/useBreakpoint.stories.tsx
+++ b/packages/components/src/hooks/useBreakpoint.stories.tsx
@@ -102,19 +102,21 @@ function LimitedBreakpoints() {
   const queries = getBreakpoints(breakpoints);
   return (
     <>
-    <div style={{
-      padding: 20,
-      backgroundColor: " var(--ha-S500)",
-    }}>
-      {bp.xxs && <p>xxs active</p>}
-      {bp.xs && <p>xs active</p>}
-      {bp.sm && <p>sm active</p>}
-      {bp.md && <p>md active</p>}
-      {bp.lg && <p>lg active</p>}
-      {bp.xlg && <p>xlg active</p>}
-    </div>
-    <p>Media queries will be derived by the input breakpoints like so:</p>
-    <Source code={JSON.stringify(queries, null, 2)} dark />
+      <div
+        style={{
+          padding: 20,
+          backgroundColor: " var(--ha-S500)",
+        }}
+      >
+        {bp.xxs && <p>xxs active</p>}
+        {bp.xs && <p>xs active</p>}
+        {bp.sm && <p>sm active</p>}
+        {bp.md && <p>md active</p>}
+        {bp.lg && <p>lg active</p>}
+        {bp.xlg && <p>xlg active</p>}
+      </div>
+      <p>Media queries will be derived by the input breakpoints like so:</p>
+      <Source code={JSON.stringify(queries, null, 2)} dark />
     </>
   );
 }
@@ -142,16 +144,21 @@ export const CustomBreakpoints: Story = {
       <h4>Disabling some breakpoints</h4>
       <p>
         By default, there&apos;s a wide range of breakpoints set, this may not be ideal for users, so you can opt-in or opt-out of certain
-        breakpoints by passing custom breakpoints to the <a href="#" onClick={(e) => {
-          e.preventDefault();
-          redirectToStory('/docs/components-themeprovider--docs');
-        }}>ThemeProvider</a>
+        breakpoints by passing custom breakpoints to the{" "}
+        <a
+          href="#"
+          onClick={(e) => {
+            e.preventDefault();
+            redirectToStory("/docs/components-themeprovider--docs");
+          }}
+        >
+          ThemeProvider
+        </a>
       </p>
       <Source dark code={customBreakpointsExample} />
       <h4>Example Output</h4>
       <p>Below, is the output from the above examples, resize your page to see the component update!</p>
       <RenderCustomBreakpoints />
-      
     </>
   ),
 };

--- a/packages/components/src/hooks/useBreakpoint.stories.tsx
+++ b/packages/components/src/hooks/useBreakpoint.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { Story, Source, Title, Description } from "@storybook/blocks";
-import { ThemeProvider, useBreakpoint } from "@components";
+import { getBreakpoints, ThemeProvider, useBreakpoint, useThemeStore } from "@components";
 import { HassConnect } from "@hass-connect-fake";
 import jsxToString from "react-element-to-jsx-string";
+import customBreakpointsExample from "./examples/some-breakpoints.code?raw";
+import { redirectToStory } from ".storybook/redirect";
 
 function Wrapper() {
   return (
@@ -90,4 +92,66 @@ export default {
 export type Story = StoryObj;
 export const Docs: Story = {
   args: {},
+};
+
+function LimitedBreakpoints() {
+  // the bp object will still contain all breakpoints, but only the ones you provided will be active
+  // the rest will be false
+  const bp = useBreakpoint();
+  const breakpoints = useThemeStore((store) => store.breakpoints);
+  const queries = getBreakpoints(breakpoints);
+  return (
+    <>
+    <div style={{
+      padding: 20,
+      backgroundColor: " var(--ha-S500)",
+    }}>
+      {bp.xxs && <p>xxs active</p>}
+      {bp.xs && <p>xs active</p>}
+      {bp.sm && <p>sm active</p>}
+      {bp.md && <p>md active</p>}
+      {bp.lg && <p>lg active</p>}
+      {bp.xlg && <p>xlg active</p>}
+    </div>
+    <p>Media queries will be derived by the input breakpoints like so:</p>
+    <Source code={JSON.stringify(queries, null, 2)} dark />
+    </>
+  );
+}
+
+function RenderCustomBreakpoints() {
+  return (
+    <HassConnect hassUrl="http://homeassistant.local:8123">
+      <ThemeProvider
+        breakpoints={{
+          xs: 576,
+          lg: 1200,
+        }}
+      />
+      <LimitedBreakpoints />
+    </HassConnect>
+  );
+}
+
+export const CustomBreakpoints: Story = {
+  args: {
+    label: "CustomBreakpoints",
+  },
+  render: () => (
+    <>
+      <h4>Disabling some breakpoints</h4>
+      <p>
+        By default, there&apos;s a wide range of breakpoints set, this may not be ideal for users, so you can opt-in or opt-out of certain
+        breakpoints by passing custom breakpoints to the <a href="#" onClick={(e) => {
+          e.preventDefault();
+          redirectToStory('/docs/components-themeprovider--docs');
+        }}>ThemeProvider</a>
+      </p>
+      <Source dark code={customBreakpointsExample} />
+      <h4>Example Output</h4>
+      <p>Below, is the output from the above examples, resize your page to see the component update!</p>
+      <RenderCustomBreakpoints />
+      
+    </>
+  ),
 };

--- a/packages/components/src/hooks/useBreakpoint.ts
+++ b/packages/components/src/hooks/useBreakpoint.ts
@@ -60,6 +60,9 @@ export function useBreakpoint(): { [key in BreakPoint]: boolean } {
       const query = queries[bp];
       if (typeof query === "string") {
         const mql = context.matchMedia(query);
+        // when dynamically switch context (windows) the mql will be null
+        // let the next iteration handle the mql
+        if (!mql) continue;
         mqlMap.set(bp, mql);
         mql.addEventListener("change", updateMatches);
       }
@@ -70,6 +73,7 @@ export function useBreakpoint(): { [key in BreakPoint]: boolean } {
 
     return () => {
       for (const mql of mqlMap.values()) {
+        if (!mql) continue;
         mql.removeEventListener("change", updateMatches);
       }
     };

--- a/packages/components/src/hooks/useBreakpoint.ts
+++ b/packages/components/src/hooks/useBreakpoint.ts
@@ -32,7 +32,6 @@ export function useBreakpoint(): { [key in BreakPoint]: boolean } {
   const windowContext = useStore((store) => store.windowContext);
   const win = windowContext ?? window;
   const queries = useMemo(() => getBreakpoints(breakpoints), [breakpoints]);
-  const initialMatches: { [key in BreakPoint]: boolean } = {
   const [matches, setMatches] = useState(() => Object.fromEntries(allBreakpoints.map((bp) => [bp, false])) as Record<BreakPoint, boolean>);
 
   useEffect(() => {

--- a/packages/components/src/hooks/useBreakpoint.ts
+++ b/packages/components/src/hooks/useBreakpoint.ts
@@ -1,5 +1,5 @@
 import { useEffect, useState, useMemo } from "react";
-import { getBreakpoints, type BreakPoint } from "@components";
+import { getBreakpoints, allBreakpoints, type BreakPoint, useThemeStore } from "@components";
 import { useHass } from "@hakit/core";
 
 /**
@@ -28,58 +28,53 @@ import { useHass } from "@hakit/core";
  */
 export function useBreakpoint(): { [key in BreakPoint]: boolean } {
   const { useStore } = useHass();
-  const breakpoints = useStore((store) => store.breakpoints);
+  const breakpoints = useThemeStore((store) => store.breakpoints);
   const windowContext = useStore((store) => store.windowContext);
   const win = windowContext ?? window;
-  const _queries = useMemo(() => getBreakpoints(breakpoints), [breakpoints]);
+  const queries = useMemo(() => getBreakpoints(breakpoints), [breakpoints]);
   const initialMatches: { [key in BreakPoint]: boolean } = {
-    xxs: false,
-    xs: false,
-    sm: false,
-    md: false,
-    lg: false,
-    xlg: false,
-  };
-
-  const [matches, setMatches] = useState(initialMatches);
+  const [matches, setMatches] = useState(() => Object.fromEntries(allBreakpoints.map((bp) => [bp, false])) as Record<BreakPoint, boolean>);
 
   useEffect(() => {
-    const handleChange = (type: BreakPoint, mediaQueryList: MediaQueryList) => {
-      setMatches((prev) => ({ ...prev, [type]: mediaQueryList.matches }));
+    const context = win || window;
+    const mqlMap = new Map<BreakPoint, MediaQueryList>();
+
+    const updateMatches = () => {
+      const newMatches = Object.fromEntries(allBreakpoints.map((bp) => [bp, false])) as Record<BreakPoint, boolean>;
+
+      for (const bp of allBreakpoints) {
+        const query = queries[bp];
+        if (typeof query === "string") {
+          const mql = mqlMap.get(bp);
+          if (mql?.matches) {
+            newMatches[bp] = true;
+            // Only one should be active at a time, so we can break here
+            break;
+          }
+        }
+      }
+
+      setMatches(newMatches);
     };
 
-    const mediaQueryLists: {
-      [key in BreakPoint]: MediaQueryList;
-    } = {
-      xxs: win.matchMedia(_queries.xxs),
-      xs: win.matchMedia(_queries.xs),
-      sm: win.matchMedia(_queries.sm),
-      md: win.matchMedia(_queries.md),
-      lg: win.matchMedia(_queries.lg),
-      xlg: win.matchMedia(_queries.xlg),
-    };
+    for (const bp of allBreakpoints) {
+      const query = queries[bp];
+      if (typeof query === "string") {
+        const mql = context.matchMedia(query);
+        mqlMap.set(bp, mql);
+        mql.addEventListener("change", updateMatches);
+      }
+    }
 
-    // Initialize
-    Object.keys(mediaQueryLists).forEach((type) => {
-      handleChange(type as BreakPoint, mediaQueryLists[type as BreakPoint]);
-    });
+    // Set initial matches
+    updateMatches();
 
-    // Add listeners
-    Object.keys(mediaQueryLists).forEach((type) => {
-      const mediaQueryList = mediaQueryLists[type as BreakPoint];
-      // intentionally using optional chaining here so if the window context used changes it doesn't throw an error
-      mediaQueryList?.addEventListener("change", (event) => handleChange(type as BreakPoint, event.currentTarget as MediaQueryList));
-    });
-
-    // Cleanup listeners
     return () => {
-      Object.keys(mediaQueryLists).forEach((type) => {
-        const mediaQueryList = mediaQueryLists[type as BreakPoint];
-        // intentionally using optional chaining here so if the window context used changes it doesn't throw an error
-        mediaQueryList?.removeEventListener("change", (event) => handleChange(type as BreakPoint, event.currentTarget as MediaQueryList));
-      });
+      for (const mql of mqlMap.values()) {
+        mql.removeEventListener("change", updateMatches);
+      }
     };
-  }, [_queries, win]);
+  }, [queries, win]);
 
   return matches;
 }

--- a/packages/components/src/index.ts
+++ b/packages/components/src/index.ts
@@ -2,11 +2,14 @@ import "./.d.ts";
 /// <reference path=".d.ts" />
 export {
   getBreakpoints,
+  allBreakpoints,
+  orderedBreakpoints,
   mq,
   getColumnSizeCSS,
   generateColumnBreakpoints,
   type AvailableQueries,
   type BreakPoint,
+  type BreakPointsWithXlg,
   type BreakPoints,
   type GridSpan,
 } from "./ThemeProvider/breakpoints";

--- a/packages/components/vite.config.ts
+++ b/packages/components/vite.config.ts
@@ -104,7 +104,7 @@ ${content}`
         'src/**/*.{ts,tsx}',
         'src/**/**/*.{ts,tsx}',
       ], {
-        ignore: ['**/*stories.ts', '**/*stories.tsx', "**/*.test.{ts,tsx}"]
+        ignore: ['**/*stories.ts', '**/*stories.tsx', "**/*.test.{ts,tsx}", "**/*.code.{ts,tsx}"]
       }).map(file => [
          // The name of the entry point
          // src/nested/foo.ts becomes nested/foo

--- a/packages/core/src/HassConnect/HassContext.tsx
+++ b/packages/core/src/HassConnect/HassContext.tsx
@@ -78,10 +78,6 @@ export interface Store {
   hassUrl: string | null;
   /** set the hassUrl */
   setHassUrl: (hassUrl: string | null) => void;
-  /** getter for breakpoints, if using @hakit/components, the breakpoints are stored here to retrieve in different locations */
-  breakpoints: Record<"xxs" | "xs" | "sm" | "md" | "lg" | "xlg", number>;
-  /** setter for breakpoints, if using @hakit/components, the breakpoints are stored here to retrieve in different locations */
-  setBreakpoints: (breakpoints: Record<"xxs" | "xs" | "sm" | "md" | "lg", number>) => void;
   /** a way to provide or overwrite default styles for any particular component */
   setGlobalComponentStyles: (styles: Partial<Record<SupportedComponentOverrides, CSSInterpolation>>) => void;
   globalComponentStyles: Partial<Record<SupportedComponentOverrides, CSSInterpolation>>;
@@ -109,15 +105,6 @@ const ignoreForDiffCheck = (
   ) as {
     [key: string]: Omit<HassEntity, "last_changed" | "last_updated" | "context">;
   };
-};
-
-export const DEFAULT_BREAKPOINTS = {
-  xxs: 600,
-  xs: 900,
-  sm: 1200,
-  md: 1536,
-  lg: 1700,
-  xlg: 1701,
 };
 
 export const useStore = create<Store>((set) => ({
@@ -182,14 +169,6 @@ export const useStore = create<Store>((set) => ({
   setConfig: (config) => set({ config }),
   error: null,
   setError: (error) => set({ error }),
-  breakpoints: DEFAULT_BREAKPOINTS,
-  setBreakpoints: (breakpoints) =>
-    set({
-      breakpoints: {
-        ...breakpoints,
-        xlg: breakpoints.lg + 1,
-      },
-    }),
   globalComponentStyles: {},
   setGlobalComponentStyles: (styles) => set(() => ({ globalComponentStyles: styles })),
 }));
@@ -244,7 +223,7 @@ export interface HassContextProps {
         status: "error";
       }
   >;
-  /** Will tell the useBreakpoints which window to match media on, if serving within an iframe it'll potentially be running in the wrong window */
+  /** Will tell the various features like breakpoints, modals and resize events which window to match media on, if serving within an iframe it'll potentially be running in the wrong window */
   windowContext?: Window;
 }
 

--- a/packages/core/src/HassConnect/Provider.tsx
+++ b/packages/core/src/HassConnect/Provider.tsx
@@ -38,7 +38,7 @@ export interface HassProviderProps {
   locale?: Locales;
   /** location to render portals @default document.body */
   portalRoot?: HTMLElement;
-  /** update the window reference that's used internally on some features, for example useBreakpoint will use the current window if not specified, and if running within an iframe this may not be expected behavior */
+  /** Will tell the various features like breakpoints, modals and resize events which window to match media on, if serving within an iframe it'll potentially be running in the wrong window */
   windowContext?: Window;
 }
 

--- a/stories/3.responsive.stories.tsx
+++ b/stories/3.responsive.stories.tsx
@@ -134,3 +134,14 @@ export const UseBreakpoint: Story = {
 };
 
 UseBreakpoint.storyName = 'useBreakpoint';
+
+
+export type CustomBreakpoints = StoryObj<typeof Empty>;
+export const CustomBreakpoints: Story = {
+  render: Empty,
+  parameters: {
+    redirectTo: '/story/components-hooks-usebreakpoint--custom-breakpoints',
+  }
+};
+
+CustomBreakpoints.storyName = 'Custom Breakpoints';

--- a/stories/3b.responsiveBreakpoints.stories.tsx
+++ b/stories/3b.responsiveBreakpoints.stories.tsx
@@ -2,6 +2,7 @@ import { Story, Source } from "@storybook/blocks";
 import type { Meta, StoryObj } from "@storybook/react";
 import { redirectToStory } from '../.storybook/redirect';
 import breakpointExample from './codeExamples/breakpointExample.code?raw';
+import { DEFAULT_BREAKPOINTS, getBreakpoints } from "@components";
 
 export default {
   title: "INTRODUCTION/Responsive Layouts/Breakpoints",
@@ -23,19 +24,12 @@ export default {
           redirectToStory('/docs/components-hooks-usebreakpoint--docs');
         }}>useBreakpoint</a>, the .md property will be true.</p>
       <p>The breakpoint settings above, translate to the following auto generated media queries:</p>
-      <Source dark code={`
-export const getBreakpoints = (breakpoints: BreakPoints): Record<BreakPoint, string> => {
-  const { xxs, xs, sm, md, lg } = breakpoints;
-  return {
-    xxs: \`(max-width: $\{xxs}px)\`,
-    xs: \`(min-width: $\{xxs + 1}px) and (max-width: $\{xs}px)\`,
-    sm: \`(min-width: $\{xs + 1}px) and (max-width: $\{sm}px)\`,
-    md: \`(min-width: $\{sm + 1}px) and (max-width: $\{md}px)\`,
-    lg: \`(min-width: $\{md + 1}px) and (max-width: $\{lg}px)\`,
-    xlg: \`(min-width: $\{lg + 1}px)\`,
-  };
-};
-`} />
+      <Source dark code={JSON.stringify(getBreakpoints(DEFAULT_BREAKPOINTS), null, 2)} />
+      <h2>Custom Breakpoints</h2>
+      <p>You can also omit certain breakpoints from the ThemeProvider, meaning you can disable some of the more granular breakpoints if need be, see <a href="#" onClick={(e) => {
+          e.preventDefault();
+          redirectToStory('/story/components-hooks-usebreakpoint--custom-breakpoints');
+        }}>Custom Breakpoints</a> for more information</p>
     </>
   },
 } satisfies Meta;


### PR DESCRIPTION
Currently, there's 6 pre-defined breakpoints which are editable, however the user may not want this many breakpoints, it may simply be overkill!

- [issue](https://github.com/shannonhochkins/ha-component-kit/issues/244) for tracking

The other reason for this feature is the editor UI I'm building will be able to define these breakpoints and by default the editor UI will only have mobile/tablet/desktop sizes enabled

## Changes
- DOCS - Documented custom breakpoints
- IMPROVEMENT - Error handling on `setBreakpoints` if the user provided invalid breakpoint values as values should be provided in a linear format
- PERFORMANCE - optimisation to useBreakpoint, now state will only update when any of the matches change
- BUGFIX - If switching window context dynamically, the window match logic will not work and will have to shift midway, this has been addressed

## Potential breaking changes
- breakpoints, setBreakpoints have been moved to the themeStore and out of @hakit/core, nothing in core consumes or uses these values, so it makes sense to move to the components package and set via the `ThemeProvider`